### PR TITLE
Implement inventory item pickups, UI grid, and spawner

### DIFF
--- a/Assets/TPSBR/Prefabs/Pickups/InventoryItemProvider.prefab
+++ b/Assets/TPSBR/Prefabs/Pickups/InventoryItemProvider.prefab
@@ -1,0 +1,92 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1965739204384756284
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2413579204384756285}
+  - component: {fileID: 213456789012345678}
+  - component: {fileID: 483920102938475611}
+  - component: {fileID: 594820192837465122}
+  m_Layer: 0
+  m_Name: InventoryItemProvider
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2413579204384756285
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1965739204384756284}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &213456789012345678
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1965739204384756284}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: -1552182283, guid: e725a070cec140c4caffb81624c8c787, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  SortKey: 0
+  ObjectInterest: 0
+  Flags: 264449
+  NestedObjects: []
+  NetworkedBehaviours:
+  - {fileID: 483920102938475611}
+  ForceRemoteRenderTimeframe: 0
+--- !u!114 &483920102938475611
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1965739204384756284}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b6eca988f2cb4717a6da4851e5eae5b9, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  _interpolationTarget: {fileID: 0}
+  _collider: {fileID: 594820192837465122}
+  _despawnTime: 60
+  _visualOffset: {x: 0, y: 0, z: 0}
+--- !u!135 &594820192837465122
+SphereCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1965739204384756284}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.35
+  m_Center: {x: 0, y: 0, z: 0}

--- a/Assets/TPSBR/Prefabs/Pickups/InventoryItemProvider.prefab.meta
+++ b/Assets/TPSBR/Prefabs/Pickups/InventoryItemProvider.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 892c06a7028b40b585f94a6ffd3f8fb0
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/TPSBR/Scripts/Gameplay/Components/Interactions.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Components/Interactions.cs
@@ -77,11 +77,15 @@
 			if (interact == false)
 				return;
 
-			if (InteractionTarget is DynamicPickup dynamicPickup && dynamicPickup.Provider is Weapon pickupWeapon)
-			{
-				_inventory.Pickup(dynamicPickup, pickupWeapon);
-			}
-			else if (InteractionTarget is WeaponPickup weaponPickup)
+                        if (InteractionTarget is DynamicPickup dynamicPickup && dynamicPickup.Provider is Weapon pickupWeapon)
+                        {
+                                _inventory.Pickup(dynamicPickup, pickupWeapon);
+                        }
+                        else if (InteractionTarget is DynamicPickup dynamicItem && dynamicItem.Provider is InventoryItemPickupProvider itemProvider)
+                        {
+                                _inventory.Pickup(dynamicItem, itemProvider);
+                        }
+                        else if (InteractionTarget is WeaponPickup weaponPickup)
 			{
 				_inventory.Pickup(weaponPickup);
 			}

--- a/Assets/TPSBR/Scripts/Gameplay/Interactions/InventoryItemSpawner.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Interactions/InventoryItemSpawner.cs
@@ -1,0 +1,87 @@
+using Fusion;
+using UnityEngine;
+using TSS.Data;
+
+namespace TPSBR
+{
+        public sealed class InventoryItemSpawner : NetworkBehaviour
+        {
+                [SerializeField]
+                private DynamicPickup _pickupPrefab;
+                [SerializeField]
+                private InventoryItemPickupProvider _itemPrefab;
+                [SerializeField]
+                private ItemDefinition[] _possibleItems;
+                [SerializeField]
+                private Vector2Int _spawnCountRange = new Vector2Int(1, 3);
+                [SerializeField]
+                private Vector2Int _quantityRange = new Vector2Int(1, 1);
+                [SerializeField]
+                private Vector3 _spawnAreaExtents = new Vector3(2f, 0.5f, 2f);
+                [SerializeField]
+                private float _spawnHeightOffset = 0.5f;
+
+                [Networked]
+                private NetworkBool _hasSpawned { get; set; }
+
+                public override void Spawned()
+                {
+                        if (HasStateAuthority == true && _hasSpawned == false)
+                        {
+                                SpawnItems();
+                                _hasSpawned = true;
+                        }
+                }
+
+                public void Respawn()
+                {
+                        if (HasStateAuthority == false)
+                                return;
+
+                        SpawnItems();
+                }
+
+                private void SpawnItems()
+                {
+                        if (_pickupPrefab == null || _itemPrefab == null)
+                                return;
+
+                        if (_possibleItems == null || _possibleItems.Length == 0)
+                                return;
+
+                        int minCount = Mathf.Max(0, _spawnCountRange.x);
+                        int maxCount = Mathf.Max(minCount, _spawnCountRange.y);
+                        int spawnCount = Random.Range(minCount, maxCount + 1);
+
+                        for (int i = 0; i < spawnCount; i++)
+                        {
+                                var definition = _possibleItems[Random.Range(0, _possibleItems.Length)];
+                                if (definition == null)
+                                        continue;
+
+                                int minQuantity = Mathf.Max(1, _quantityRange.x);
+                                int maxQuantity = Mathf.Max(minQuantity, _quantityRange.y);
+                                byte quantity = (byte)Mathf.Clamp(Random.Range(minQuantity, maxQuantity + 1), 1, byte.MaxValue);
+
+                                Vector3 randomOffset = new Vector3(
+                                        Random.Range(-_spawnAreaExtents.x, _spawnAreaExtents.x),
+                                        Random.Range(-_spawnAreaExtents.y, _spawnAreaExtents.y),
+                                        Random.Range(-_spawnAreaExtents.z, _spawnAreaExtents.z));
+
+                                Vector3 spawnPosition = transform.position + randomOffset;
+                                spawnPosition.y += _spawnHeightOffset;
+
+                                Quaternion rotation = Quaternion.Euler(0f, Random.Range(0f, 360f), 0f);
+
+                                var provider = Runner.Spawn(_itemPrefab, spawnPosition, rotation);
+                                provider.Initialize(definition, quantity);
+
+                                Runner.Spawn(_pickupPrefab, spawnPosition, rotation, PlayerRef.None, (runner, obj) =>
+                                {
+                                        var pickup = obj.GetComponent<DynamicPickup>();
+                                        pickup.AssignObject(provider.Object.Id);
+                                });
+                        }
+                }
+        }
+}

--- a/Assets/TPSBR/Scripts/Gameplay/Interactions/InventoryItemSpawner.cs.meta
+++ b/Assets/TPSBR/Scripts/Gameplay/Interactions/InventoryItemSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 688ccf1bc83840fe9314e400dc930b62
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/TPSBR/Scripts/Gameplay/Interactions/Pickups/InventoryItemPickupProvider.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Interactions/Pickups/InventoryItemPickupProvider.cs
@@ -1,0 +1,199 @@
+using Fusion;
+using UnityEngine;
+using TSS.Data;
+
+namespace TPSBR
+{
+        public sealed class InventoryItemPickupProvider : NetworkBehaviour, IDynamicPickupProvider
+        {
+                [SerializeField]
+                private Transform _interpolationTarget;
+                [SerializeField]
+                private Collider _collider;
+                [SerializeField]
+                private float _despawnTime = 60f;
+                [SerializeField]
+                private Vector3 _visualOffset;
+
+                [Networked]
+                public int ItemDefinitionId { get; private set; }
+                [Networked]
+                public byte Quantity { get; private set; }
+                [Networked]
+                public NetworkString<_32> ConfigurationHash { get; private set; }
+
+                public ItemDefinition Definition => _definition;
+
+                public string Name => _definition != null ? _definition.Name : string.Empty;
+                public string Description
+                {
+                        get
+                        {
+                                if (_definition == null)
+                                        return string.Empty;
+
+                                return Quantity > 1 ? $"{Quantity}x {_definition.Name}" : _definition.Name;
+                        }
+                }
+
+                public Transform InterpolationTarget => _interpolationTarget != null ? _interpolationTarget : transform;
+                public Collider Collider => _collider;
+                public float DespawnTime => _despawnTime;
+
+                private ItemDefinition _definition;
+                private GameObject _visualInstance;
+                private bool _visualInitialized;
+
+                public void Initialize(ItemDefinition definition, byte quantity, NetworkString<_32> configurationHash = default)
+                {
+                        if (HasStateAuthority == false)
+                                return;
+
+                        if (definition == null)
+                                return;
+
+                        ItemDefinitionId = definition.ID;
+                        Quantity = quantity;
+                        ConfigurationHash = configurationHash;
+                        _definition = definition;
+                        _visualInitialized = false;
+
+                        RefreshVisual();
+                }
+
+                public void SetQuantity(byte quantity)
+                {
+                        if (HasStateAuthority == true)
+                        {
+                                Quantity = quantity;
+                        }
+                }
+
+                public void Assigned(DynamicPickup pickup)
+                {
+                        if (_collider != null)
+                        {
+                                _collider.enabled = true;
+                        }
+                }
+
+                public void Unassigned(DynamicPickup pickup)
+                {
+                        if (_collider != null)
+                        {
+                                _collider.enabled = false;
+                        }
+                }
+
+                public override void Spawned()
+                {
+                        base.Spawned();
+
+                        if (_interpolationTarget == null)
+                        {
+                                _interpolationTarget = transform;
+                        }
+
+                        if (_collider == null)
+                        {
+                                _collider = GetComponent<Collider>();
+                        }
+
+                        if (_collider == null)
+                        {
+                                var sphere = gameObject.AddComponent<SphereCollider>();
+                                sphere.isTrigger = true;
+                                sphere.radius = 0.35f;
+                                _collider = sphere;
+                        }
+
+                        if (_collider != null)
+                        {
+                                _collider.enabled = false;
+                                _collider.gameObject.layer = ObjectLayer.Interaction;
+                        }
+
+                        EnsureDefinition();
+                        RefreshVisual();
+                }
+
+                public override void FixedUpdateNetwork()
+                {
+                        base.FixedUpdateNetwork();
+
+                        if (_definition == null)
+                        {
+                                EnsureDefinition();
+                                RefreshVisual();
+                        }
+                }
+
+                public override void Render()
+                {
+                        if (_definition == null)
+                        {
+                                EnsureDefinition();
+                                RefreshVisual();
+                        }
+                }
+
+                public override void Despawned(NetworkRunner runner, bool hasState)
+                {
+                        base.Despawned(runner, hasState);
+                        ClearVisual();
+                        _definition = null;
+                        _visualInitialized = false;
+                }
+
+                private void EnsureDefinition()
+                {
+                        if (_definition != null)
+                                return;
+
+                        if (ItemDefinitionId == 0)
+                                return;
+
+                        _definition = ItemDefinition.Get(ItemDefinitionId);
+                }
+
+                private void RefreshVisual()
+                {
+                        if (_visualInitialized == true)
+                                return;
+
+                        if (_definition == null)
+                                return;
+
+                        var graphic = _definition.WorldGraphic;
+                        if (graphic == null)
+                                return;
+
+                        ClearVisual();
+
+                        var parent = InterpolationTarget;
+                        _visualInstance = Instantiate(graphic, parent);
+                        _visualInstance.transform.localPosition += _visualOffset;
+                        _visualInstance.transform.localRotation = Quaternion.identity;
+                        _visualInstance.transform.localScale = Vector3.one;
+
+                        var rigidbody = _visualInstance.GetComponent<Rigidbody>();
+                        if (rigidbody != null)
+                        {
+                                Destroy(rigidbody);
+                        }
+
+                        _visualInitialized = true;
+                }
+
+                private void ClearVisual()
+                {
+                        if (_visualInstance != null)
+                        {
+                                Destroy(_visualInstance);
+                                _visualInstance = null;
+                        }
+
+                        _visualInitialized = false;
+                }
+        }
+}

--- a/Assets/TPSBR/Scripts/Gameplay/Interactions/Pickups/InventoryItemPickupProvider.cs.meta
+++ b/Assets/TPSBR/Scripts/Gameplay/Interactions/Pickups/InventoryItemPickupProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b6eca988f2cb4717a6da4851e5eae5b9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
+++ b/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
@@ -11,8 +11,11 @@ namespace TPSBR.UI
         public bool MenuVisible => _menuVisible;
         // PRIVATE MEMBERS
         [SerializeField] private UIButton _cancelButton;
+        [SerializeField] private UIInventoryGrid _inventoryGrid;
 
         private bool _menuVisible;
+        private Agent _boundAgent;
+        private Inventory _boundInventory;
 
         // PUBLIC METHODS
 
@@ -42,12 +45,28 @@ namespace TPSBR.UI
         {
             base.OnInitialize();
             
-            _cancelButton.onClick.AddListener(OnCancelButton);
+            if (_inventoryGrid == null)
+            {
+                _inventoryGrid = GetComponentInChildren<UIInventoryGrid>(true);
+            }
+
+            if (_cancelButton != null)
+            {
+                _cancelButton.onClick.AddListener(OnCancelButton);
+            }
         }
 
         protected override void OnDeinitialize()
         {
-            _cancelButton.onClick.RemoveListener(OnCancelButton);
+            if (_inventoryGrid != null)
+            {
+                _inventoryGrid.Bind(null);
+            }
+
+            if (_cancelButton != null)
+            {
+                _cancelButton.onClick.RemoveListener(OnCancelButton);
+            }
 
             base.OnDeinitialize();
         }
@@ -59,6 +78,15 @@ namespace TPSBR.UI
             Animation.SampleStart();
             _menuVisible = false;
             CanvasGroup.interactable = false;
+
+            RefreshInventoryBinding();
+        }
+
+        protected override void OnTick()
+        {
+            base.OnTick();
+
+            RefreshInventoryBinding();
         }
 
         protected override void OnCloseButton()
@@ -109,6 +137,28 @@ namespace TPSBR.UI
         private void OnCancelButton()
         {
             OnCloseButton();
+        }
+
+        private void RefreshInventoryBinding()
+        {
+            if (Context == null)
+            {
+                if (_boundAgent != null)
+                {
+                    _boundAgent = null;
+                    _boundInventory = null;
+                    _inventoryGrid?.Bind(null);
+                }
+                return;
+            }
+
+            var agent = Context.ObservedAgent;
+            if (_boundAgent == agent)
+                return;
+
+            _boundAgent = agent;
+            _boundInventory = agent != null ? agent.Inventory : null;
+            _inventoryGrid?.Bind(_boundInventory);
         }
     }
 }

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
@@ -1,0 +1,199 @@
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace TPSBR.UI
+{
+        public class UIInventoryGrid : UIWidget
+        {
+                [SerializeField]
+                private RectTransform _dragLayer;
+
+                private UIItemSlot[] _slots;
+                private Inventory _inventory;
+                private UIItemSlot _dragSource;
+                private RectTransform _dragIcon;
+                private Image _dragImage;
+                private CanvasGroup _dragCanvasGroup;
+
+                protected override void OnInitialize()
+                {
+                        base.OnInitialize();
+
+                        _slots = GetComponentsInChildren<UIItemSlot>(true);
+
+                        for (int i = 0; i < _slots.Length; i++)
+                        {
+                                _slots[i].InitializeSlot(this, i);
+                        }
+                }
+
+                protected override void OnDeinitialize()
+                {
+                        Bind(null);
+                        base.OnDeinitialize();
+                }
+
+                internal void Bind(Inventory inventory)
+                {
+                        if (_inventory == inventory)
+                                return;
+
+                        if (_inventory != null)
+                        {
+                                _inventory.ItemSlotChanged -= OnItemSlotChanged;
+                        }
+
+                        _inventory = inventory;
+
+                        if (_inventory != null)
+                        {
+                                for (int i = 0; i < _slots.Length; i++)
+                                {
+                                        UpdateSlot(i, _inventory.GetItemSlot(i));
+                                }
+
+                                _inventory.ItemSlotChanged += OnItemSlotChanged;
+                        }
+                        else
+                        {
+                                for (int i = 0; i < _slots.Length; i++)
+                                {
+                                        _slots[i].Clear();
+                                }
+                        }
+
+                        SetDragVisible(false);
+                        _dragSource = null;
+                }
+
+                internal void BeginSlotDrag(UIItemSlot slot, PointerEventData eventData)
+                {
+                        if (slot == null || _inventory == null)
+                                return;
+
+                        _dragSource = slot;
+                        EnsureDragVisual();
+                        UpdateDragIcon(slot.IconSprite, slot.Quantity, slot.SlotRectTransform.rect.size);
+                        SetDragVisible(true);
+                        UpdateDragPosition(eventData);
+                }
+
+                internal void UpdateSlotDrag(PointerEventData eventData)
+                {
+                        if (_dragSource == null)
+                                return;
+
+                        UpdateDragPosition(eventData);
+                }
+
+                internal void EndSlotDrag(UIItemSlot slot, PointerEventData eventData)
+                {
+                        if (_dragSource != slot)
+                                return;
+
+                        _dragSource = null;
+                        SetDragVisible(false);
+                }
+
+                internal void HandleSlotDrop(UIItemSlot source, UIItemSlot target)
+                {
+                        if (_inventory == null)
+                                return;
+
+                        SetDragVisible(false);
+                        _dragSource = null;
+
+                        if (source.Index == target.Index)
+                                return;
+
+                        _inventory.RequestMoveItem(source.Index, target.Index);
+                }
+
+                private void OnItemSlotChanged(int index, InventorySlot slot)
+                {
+                        UpdateSlot(index, slot);
+                }
+
+                private void UpdateSlot(int index, InventorySlot slot)
+                {
+                        if (_slots == null || index < 0 || index >= _slots.Length)
+                                return;
+
+                        if (slot.IsEmpty)
+                        {
+                                _slots[index].Clear();
+                                return;
+                        }
+
+                        var definition = slot.GetDefinition();
+                        var sprite = definition != null ? definition.IconSprite : null;
+
+                        _slots[index].SetItem(sprite, slot.Quantity);
+                }
+
+                private void EnsureDragVisual()
+                {
+                        if (_dragIcon != null)
+                                return;
+
+                        var parent = _dragLayer != null ? _dragLayer : SceneUI.Canvas.transform as RectTransform;
+                        var dragObject = new GameObject("InventoryDrag", typeof(RectTransform), typeof(CanvasGroup), typeof(Image));
+                        dragObject.transform.SetParent(parent, false);
+
+                        _dragIcon = dragObject.GetComponent<RectTransform>();
+                        _dragCanvasGroup = dragObject.GetComponent<CanvasGroup>();
+                        _dragImage = dragObject.GetComponent<Image>();
+
+                        _dragCanvasGroup.blocksRaycasts = false;
+                        _dragCanvasGroup.interactable = false;
+                        _dragImage.raycastTarget = false;
+                        _dragImage.preserveAspect = true;
+
+                        dragObject.SetActive(false);
+                }
+
+                private void UpdateDragIcon(Sprite sprite, int quantity, Vector2 size)
+                {
+                        if (_dragIcon == null)
+                                return;
+
+                        if (sprite == null || quantity <= 0)
+                        {
+                                SetDragVisible(false);
+                                return;
+                        }
+
+                        _dragImage.sprite = sprite;
+                        _dragImage.color = Color.white;
+                        _dragIcon.sizeDelta = size;
+                }
+
+                private void UpdateDragPosition(PointerEventData eventData)
+                {
+                        if (_dragIcon == null)
+                                return;
+
+                        RectTransform canvasRect = SceneUI.Canvas.transform as RectTransform;
+                        if (canvasRect == null)
+                                return;
+
+                        if (RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRect, eventData.position, SceneUI.Canvas.worldCamera, out Vector2 localPoint))
+                        {
+                                _dragIcon.localPosition = localPoint;
+                        }
+                }
+
+                private void SetDragVisible(bool visible)
+                {
+                        if (_dragIcon == null)
+                                return;
+
+                        _dragIcon.gameObject.SetActive(visible);
+                        if (_dragCanvasGroup != null)
+                        {
+                                _dragCanvasGroup.alpha = visible ? 1f : 0f;
+                        }
+                }
+        }
+}

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs.meta
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1892fae9dc5a4133a00fe86557d7526c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/TPSBR/UI/Prefabs/GameplayViews/UIInventoryView.prefab
+++ b/Assets/TPSBR/UI/Prefabs/GameplayViews/UIInventoryView.prefab
@@ -322,6 +322,7 @@ GameObject:
   m_Component:
   - component: {fileID: 8667791998921046791}
   - component: {fileID: 718352103281036619}
+  - component: {fileID: 5632109876543210987}
   m_Layer: 5
   m_Name: Grid
   m_TagString: Untagged
@@ -368,8 +369,8 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 8a8695521f0d02e499659fee002a26c2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   m_Padding:
     m_Left: 0
     m_Right: 0
@@ -382,6 +383,19 @@ MonoBehaviour:
   m_Spacing: {x: 10, y: 10}
   m_Constraint: 0
   m_ConstraintCount: 2
+--- !u!114 &5632109876543210987
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6710325688762955717}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1892fae9dc5a4133a00fe86557d7526c, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  _dragLayer: {fileID: 0}
 --- !u!1001 &43215082681018927
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/TSS/InventoryItem.cs
+++ b/Assets/TSS/InventoryItem.cs
@@ -1,0 +1,14 @@
+using UnityEngine;
+using UnityEngine.Serialization;
+
+namespace TSS.Data
+{
+    public abstract class InventoryItem : DataDefinition
+    {
+        [FormerlySerializedAs("WorldVisuals")]
+        [SerializeField]
+        private GameObject _worldGraphic;
+
+        public GameObject WorldGraphic => _worldGraphic;
+    }
+}

--- a/Assets/TSS/InventoryItem.cs.meta
+++ b/Assets/TSS/InventoryItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 59ce13a034174b89b88762086d1bcb8b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/TSS/ItemDefinition.cs
+++ b/Assets/TSS/ItemDefinition.cs
@@ -1,63 +1,107 @@
 using System.Collections.Generic;
+using System;
 using Unity.Burst;
 using Unity.Collections;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace TSS.Data
 {
     [CreateAssetMenu(fileName = "WeaponDefinition", menuName = "TSS/Data Definitions/Weapon")]
-    public class ItemDefinition : DataDefinition
+    public class ItemDefinition : InventoryItem
     {
         [SerializeField] private string displayName;
-        [SerializeField] private Texture2D icon;
+        [FormerlySerializedAs("icon")]
+        [SerializeField] private Texture2D _iconTexture;
+        [SerializeField] private Sprite _iconSprite;
         [SerializeField] private ushort maxStack = 100;
-        public GameObject WorldVisuals; // prefab for world/item pickup visuals
-        
-        static Dictionary<int, ItemDefinition> _map;
-        static readonly SharedStatic<NativeHashMap<int, ushort>> _maxStacks =
+
+        [NonSerialized]
+        private Sprite _generatedSprite;
+
+        private static Dictionary<int, ItemDefinition> _map;
+        private static readonly SharedStatic<NativeHashMap<int, ushort>> _maxStacks =
             SharedStatic<NativeHashMap<int, ushort>>.GetOrCreate<MaxStacksContext>();
-        struct MaxStacksContext
+
+        private struct MaxStacksContext
         {
         }
+
         public override string Name => displayName;
-        public override Texture2D Icon => icon;
+        public override Texture2D Icon => _iconSprite != null ? _iconSprite.texture : _iconTexture;
         public ushort MaxStack => maxStack;
-        
-        
+        public Sprite IconSprite => _iconSprite != null ? _iconSprite : GetOrCreateSprite();
+
         public static ushort GetMaxStack(int id)
         {
             ref var maxStacks = ref _maxStacks.Data;
             if (!maxStacks.IsCreated) return 0;
             return maxStacks.TryGetValue(id, out var max) ? max : (ushort)0;
         }
+
         public static ItemDefinition Get(int id)
         {
             if (_map == null)
+            {
                 LoadAll();
+            }
+
             _map.TryGetValue(id, out var def);
             return def;
         }
+
         public static void LoadAll()
         {
             _map = new Dictionary<int, ItemDefinition>();
 
             ref var maxStacks = ref _maxStacks.Data;
 
-            // Dispose previous hash map if reloading.
             if (maxStacks.IsCreated)
+            {
                 maxStacks.Dispose();
+            }
 
-            var defs = Resources.LoadAll<ItemDefinition>("");
+            var defs = Resources.LoadAll<ItemDefinition>(string.Empty);
             maxStacks = new NativeHashMap<int, ushort>(defs.Length, Allocator.Persistent);
 
             foreach (var def in defs)
             {
-                if (def == null) continue;
+                if (def == null)
+                {
+                    continue;
+                }
+
                 _map[def.ID] = def;
                 maxStacks.TryAdd(def.ID, def.MaxStack);
             }
-            
+
             Debug.Log($"Total items in registry: {_map.Count}");
+        }
+
+        private Sprite GetOrCreateSprite()
+        {
+            if (_iconSprite != null)
+            {
+                return _iconSprite;
+            }
+
+            if (_iconTexture == null)
+            {
+                return null;
+            }
+
+            if (_generatedSprite != null)
+            {
+                return _generatedSprite;
+            }
+
+            _generatedSprite = Sprite.Create(
+                _iconTexture,
+                new Rect(0f, 0f, _iconTexture.width, _iconTexture.height),
+                new Vector2(0.5f, 0.5f),
+                100f);
+            _generatedSprite.name = $"{name}_Icon";
+            return _generatedSprite;
         }
     }
 }

--- a/Assets/UIItemSlot.cs
+++ b/Assets/UIItemSlot.cs
@@ -1,16 +1,187 @@
+using TMPro;
 using UnityEngine;
 using UnityEngine.EventSystems;
+using UnityEngine.UI;
 
 namespace TPSBR.UI
 {
-    public class UIItemSlot : UIWidget
+    public class UIItemSlot : UIWidget, IBeginDragHandler, IDragHandler, IEndDragHandler, IDropHandler
     {
+        private UIInventoryGrid _owner;
         private UIButton _button;
+        private CanvasGroup _canvasGroup;
+        private Image _iconImage;
+        private TextMeshProUGUI _quantityLabel;
+        private Sprite _iconSprite;
+        private int _quantity;
+        private bool _isDragging;
+
+        public int Index { get; private set; } = -1;
+        public RectTransform SlotRectTransform => RectTransform;
+        internal Sprite IconSprite => _iconSprite;
+        internal int Quantity => _quantity;
+        internal bool HasItem => _iconSprite != null && _quantity > 0;
 
         protected override void OnInitialize()
         {
             base.OnInitialize();
+
             _button = GetComponent<UIButton>();
+            EnsureCanvasGroup();
+        }
+
+        protected override void OnDeinitialize()
+        {
+            _owner = null;
+            Index = -1;
+            base.OnDeinitialize();
+        }
+
+        internal void InitializeSlot(UIInventoryGrid owner, int index)
+        {
+            _owner = owner;
+            Index = index;
+            Clear();
+        }
+
+        internal void SetItem(Sprite icon, int quantity)
+        {
+            _iconSprite = icon;
+            _quantity = quantity;
+
+            if (icon != null)
+            {
+                EnsureIconImage();
+                _iconImage.sprite = icon;
+                _iconImage.color = Color.white;
+                _iconImage.enabled = true;
+            }
+            else if (_iconImage != null)
+            {
+                _iconImage.sprite = null;
+                _iconImage.enabled = false;
+            }
+
+            if (quantity > 1)
+            {
+                EnsureQuantityLabel();
+                _quantityLabel.text = quantity.ToString();
+                _quantityLabel.gameObject.SetActive(true);
+            }
+            else if (_quantityLabel != null)
+            {
+                _quantityLabel.gameObject.SetActive(false);
+            }
+        }
+
+        internal void Clear()
+        {
+            SetItem(null, 0);
+        }
+
+        public void OnBeginDrag(PointerEventData eventData)
+        {
+            if (_owner == null)
+                return;
+
+            if (HasItem == false)
+                return;
+
+            _isDragging = true;
+            EnsureCanvasGroup();
+            _canvasGroup.alpha = 0.35f;
+            _canvasGroup.blocksRaycasts = false;
+
+            _owner.BeginSlotDrag(this, eventData);
+        }
+
+        public void OnDrag(PointerEventData eventData)
+        {
+            if (_owner == null || _isDragging == false)
+                return;
+
+            _owner.UpdateSlotDrag(eventData);
+        }
+
+        public void OnEndDrag(PointerEventData eventData)
+        {
+            if (_owner == null || _isDragging == false)
+                return;
+
+            _isDragging = false;
+            EnsureCanvasGroup();
+            _canvasGroup.alpha = 1f;
+            _canvasGroup.blocksRaycasts = true;
+
+            _owner.EndSlotDrag(this, eventData);
+        }
+
+        public void OnDrop(PointerEventData eventData)
+        {
+            if (_owner == null)
+                return;
+
+            var sourceSlot = eventData.pointerDrag != null ? eventData.pointerDrag.GetComponent<UIItemSlot>() : null;
+            if (sourceSlot == null || sourceSlot == this)
+                return;
+
+            _owner.HandleSlotDrop(sourceSlot, this);
+        }
+
+        private void EnsureCanvasGroup()
+        {
+            if (_canvasGroup != null)
+                return;
+
+            _canvasGroup = GetComponent<CanvasGroup>();
+            if (_canvasGroup == null)
+            {
+                _canvasGroup = gameObject.AddComponent<CanvasGroup>();
+            }
+        }
+
+        private void EnsureIconImage()
+        {
+            if (_iconImage != null)
+                return;
+
+            var iconObject = new GameObject("Icon", typeof(RectTransform));
+            iconObject.transform.SetParent(transform, false);
+
+            var rect = iconObject.GetComponent<RectTransform>();
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = Vector2.zero;
+            rect.offsetMax = Vector2.zero;
+
+            _iconImage = iconObject.AddComponent<Image>();
+            _iconImage.preserveAspect = true;
+            _iconImage.raycastTarget = false;
+        }
+
+        private void EnsureQuantityLabel()
+        {
+            if (_quantityLabel != null)
+                return;
+
+            var labelObject = new GameObject("Quantity", typeof(RectTransform));
+            labelObject.transform.SetParent(transform, false);
+
+            var rect = labelObject.GetComponent<RectTransform>();
+            rect.anchorMin = Vector2.zero;
+            rect.anchorMax = Vector2.one;
+            rect.offsetMin = new Vector2(6f, 6f);
+            rect.offsetMax = new Vector2(-6f, -6f);
+
+            _quantityLabel = labelObject.AddComponent<TextMeshProUGUI>();
+            _quantityLabel.raycastTarget = false;
+            _quantityLabel.alignment = TextAlignmentOptions.BottomRight;
+            _quantityLabel.fontSize = 24f;
+
+            if (TMP_Settings.defaultFontAsset != null)
+            {
+                _quantityLabel.font = TMP_Settings.defaultFontAsset;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a base `InventoryItem` definition with world graphics and extend `ItemDefinition` with icon utilities and registry helpers
- expand the gameplay `Inventory` to manage networked item slots, pickups, and movement, exposing events for UI binding and updating interactions
- create item pickup provider and random spawner prefabs/scripts plus UI grid & slot widgets for drag-and-drop inventory display

## Testing
- not run (Unity editor required)


------
https://chatgpt.com/codex/tasks/task_b_68e43e0c50a4832683c5bab8cb7a5999