### PR TITLE
Add inventory hotbar with drag-and-drop weapon assignment

### DIFF
--- a/Assets/TPSBR/Scripts/Gameplay/Agent/AgentInput.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Agent/AgentInput.cs
@@ -619,37 +619,12 @@ namespace TPSBR
 			if (keyboard.digit2Key.wasPressedThisFrame == true) { weaponSlot = 1; }
 			if (keyboard.digit3Key.wasPressedThisFrame == true) { weaponSlot = 2; }
 			if (keyboard.digit4Key.wasPressedThisFrame == true) { weaponSlot = 3; }
-			if (keyboard.digit5Key.wasPressedThisFrame == true) { weaponSlot = 4; }
-
-			if (weaponSlot < 0 && keyboard.gKey.wasPressedThisFrame == true)
-			{
-				weaponSlot = 3; // Cycle grenades
-			}
-
-			if (weaponSlot < 0)
-				return 0;
-
-			if (weaponSlot <= 2)
-				return (byte)(weaponSlot + 1); // Standard weapon switch
-
-			// Grenades (grenades are under slot 5, 6, 7 - but we cycle them with 4 numped key)
-			if (weaponSlot == 3)
-			{
-				int currentWeaponSlot = _agent.Inventory.CurrentWeaponSlot;
-				int grenadesStart = IsCyclingGrenades == true && currentWeaponSlot < 7 ? Mathf.Max(currentWeaponSlot, 4) : 4;
-
-				int grenadeToSwitch = _agent.Inventory.GetNextWeaponSlot(grenadesStart, 4);
-
-				_grenadesCyclingStartTime = Time.time;
-
-				if (grenadeToSwitch > 0 && grenadeToSwitch != currentWeaponSlot)
-				{
-					return (byte)(grenadeToSwitch + 1);
-				}
-			}
-
-			return 0;
-		}
+			
+				if (weaponSlot < 0)
+					return 0;
+			
+			return (byte)(weaponSlot + 1);
+                }
 
 		private void SetDefaults()
 		{

--- a/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
+++ b/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
@@ -12,6 +12,7 @@ namespace TPSBR.UI
         // PRIVATE MEMBERS
         [SerializeField] private UIButton _cancelButton;
         [SerializeField] private UIInventoryGrid _inventoryGrid;
+        [SerializeField] private UIHotbar _hotbar;
 
         private bool _menuVisible;
         private Agent _boundAgent;
@@ -50,6 +51,11 @@ namespace TPSBR.UI
                 _inventoryGrid = GetComponentInChildren<UIInventoryGrid>(true);
             }
 
+            if (_hotbar == null)
+            {
+                _hotbar = GetComponentInChildren<UIHotbar>(true);
+            }
+
             if (_cancelButton != null)
             {
                 _cancelButton.onClick.AddListener(OnCancelButton);
@@ -61,6 +67,11 @@ namespace TPSBR.UI
             if (_inventoryGrid != null)
             {
                 _inventoryGrid.Bind(null);
+            }
+
+            if (_hotbar != null)
+            {
+                _hotbar.Bind(null);
             }
 
             if (_cancelButton != null)
@@ -148,6 +159,7 @@ namespace TPSBR.UI
                     _boundAgent = null;
                     _boundInventory = null;
                     _inventoryGrid?.Bind(null);
+                    _hotbar?.Bind(null);
                 }
                 return;
             }
@@ -159,6 +171,7 @@ namespace TPSBR.UI
             _boundAgent = agent;
             _boundInventory = agent != null ? agent.Inventory : null;
             _inventoryGrid?.Bind(_boundInventory);
+            _hotbar?.Bind(_boundInventory);
         }
     }
 }

--- a/Assets/TPSBR/Scripts/UI/Widgets/IUIItemSlotOwner.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/IUIItemSlotOwner.cs
@@ -1,0 +1,12 @@
+using UnityEngine.EventSystems;
+
+namespace TPSBR.UI
+{
+    internal interface IUIItemSlotOwner
+    {
+        void BeginSlotDrag(UIItemSlot slot, PointerEventData eventData);
+        void UpdateSlotDrag(PointerEventData eventData);
+        void EndSlotDrag(UIItemSlot slot, PointerEventData eventData);
+        void HandleSlotDrop(UIItemSlot source, UIItemSlot target);
+    }
+}

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
@@ -1,0 +1,212 @@
+using TPSBR;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
+
+namespace TPSBR.UI
+{
+    public class UIHotbar : UIWidget, IUIItemSlotOwner
+    {
+        [SerializeField]
+        private RectTransform _dragLayer;
+
+        private UIItemSlot[] _slots;
+        private Inventory _inventory;
+        private UIItemSlot _dragSource;
+        private RectTransform _dragIcon;
+        private Image _dragImage;
+        private CanvasGroup _dragCanvasGroup;
+
+        protected override void OnInitialize()
+        {
+            base.OnInitialize();
+
+            _slots = GetComponentsInChildren<UIItemSlot>(true);
+
+            for (int i = 0; i < _slots.Length; i++)
+            {
+                _slots[i].InitializeSlot(this, i);
+            }
+        }
+
+        protected override void OnDeinitialize()
+        {
+            Bind(null);
+            base.OnDeinitialize();
+        }
+
+        internal void Bind(Inventory inventory)
+        {
+            if (_inventory == inventory)
+                return;
+
+            if (_inventory != null)
+            {
+                _inventory.HotbarSlotChanged -= OnHotbarSlotChanged;
+            }
+
+            _inventory = inventory;
+
+            if (_inventory != null)
+            {
+                _inventory.HotbarSlotChanged += OnHotbarSlotChanged;
+
+                for (int i = 0; i < _slots.Length; i++)
+                {
+                    var weapon = _inventory.GetWeapon(i + 1);
+                    UpdateSlot(i, weapon);
+                }
+            }
+            else
+            {
+                for (int i = 0; i < _slots.Length; i++)
+                {
+                    _slots[i].Clear();
+                }
+            }
+
+            SetDragVisible(false);
+            _dragSource = null;
+        }
+
+        void IUIItemSlotOwner.BeginSlotDrag(UIItemSlot slot, PointerEventData eventData)
+        {
+            if (_inventory == null)
+                return;
+
+            if (slot == null || slot.HasItem == false)
+                return;
+
+            _dragSource = slot;
+            EnsureDragVisual();
+            UpdateDragIcon(slot.IconSprite, slot.Quantity, slot.SlotRectTransform.rect.size);
+            SetDragVisible(true);
+            UpdateDragPosition(eventData);
+        }
+
+        void IUIItemSlotOwner.UpdateSlotDrag(PointerEventData eventData)
+        {
+            if (_dragSource == null)
+                return;
+
+            UpdateDragPosition(eventData);
+        }
+
+        void IUIItemSlotOwner.EndSlotDrag(UIItemSlot slot, PointerEventData eventData)
+        {
+            if (_dragSource != slot)
+                return;
+
+            _dragSource = null;
+            SetDragVisible(false);
+        }
+
+        void IUIItemSlotOwner.HandleSlotDrop(UIItemSlot source, UIItemSlot target)
+        {
+            if (_inventory == null || target == null)
+                return;
+
+            if (source == null)
+                return;
+
+            if (ReferenceEquals(source.Owner, this) == true)
+            {
+                _inventory.RequestSwapHotbar(source.Index, target.Index);
+            }
+            else
+            {
+                _inventory.RequestAssignHotbar(source.Index, target.Index);
+            }
+        }
+
+        private void OnHotbarSlotChanged(int index, Weapon weapon)
+        {
+            int slotIndex = index - 1;
+            if (_slots == null)
+                return;
+
+            if (slotIndex < 0 || slotIndex >= _slots.Length)
+                return;
+
+            UpdateSlot(slotIndex, weapon);
+        }
+
+        private void UpdateSlot(int index, Weapon weapon)
+        {
+            if (_slots == null || index < 0 || index >= _slots.Length)
+                return;
+
+            if (weapon == null)
+            {
+                _slots[index].Clear();
+                return;
+            }
+
+            _slots[index].SetItem(weapon.Icon, 1);
+        }
+
+        private void EnsureDragVisual()
+        {
+            if (_dragIcon != null)
+                return;
+
+            var parent = _dragLayer != null ? _dragLayer : SceneUI.Canvas.transform as RectTransform;
+            var dragObject = new GameObject("HotbarDrag", typeof(RectTransform), typeof(CanvasGroup), typeof(Image));
+            dragObject.transform.SetParent(parent, false);
+
+            _dragIcon = dragObject.GetComponent<RectTransform>();
+            _dragCanvasGroup = dragObject.GetComponent<CanvasGroup>();
+            _dragImage = dragObject.GetComponent<Image>();
+
+            _dragCanvasGroup.blocksRaycasts = false;
+            _dragCanvasGroup.interactable = false;
+            _dragImage.raycastTarget = false;
+            _dragImage.preserveAspect = true;
+
+            dragObject.SetActive(false);
+        }
+
+        private void UpdateDragIcon(Sprite sprite, int quantity, Vector2 size)
+        {
+            if (_dragIcon == null)
+                return;
+
+            if (sprite == null || quantity <= 0)
+            {
+                SetDragVisible(false);
+                return;
+            }
+
+            _dragImage.sprite = sprite;
+            _dragImage.color = Color.white;
+            _dragIcon.sizeDelta = size;
+        }
+
+        private void UpdateDragPosition(PointerEventData eventData)
+        {
+            if (_dragIcon == null)
+                return;
+
+            RectTransform canvasRect = SceneUI.Canvas.transform as RectTransform;
+            if (canvasRect == null)
+                return;
+
+            if (RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRect, eventData.position, SceneUI.Canvas.worldCamera, out Vector2 localPoint))
+            {
+                _dragIcon.localPosition = localPoint;
+            }
+        }
+
+        private void SetDragVisible(bool visible)
+        {
+            if (_dragIcon == null)
+                return;
+
+            _dragIcon.gameObject.SetActive(visible);
+            if (_dragCanvasGroup != null)
+            {
+                _dragCanvasGroup.alpha = visible ? 1f : 0f;
+            }
+        }
+    }
+}

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs.meta
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 92e83c7163ef4e5e8b3c5984c0e9f52b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
@@ -4,7 +4,7 @@ using UnityEngine.UI;
 
 namespace TPSBR.UI
 {
-        public class UIInventoryGrid : UIWidget
+        public class UIInventoryGrid : UIWidget, IUIItemSlotOwner
         {
                 [SerializeField]
                 private RectTransform _dragLayer;
@@ -67,7 +67,7 @@ namespace TPSBR.UI
                         _dragSource = null;
                 }
 
-                internal void BeginSlotDrag(UIItemSlot slot, PointerEventData eventData)
+                void IUIItemSlotOwner.BeginSlotDrag(UIItemSlot slot, PointerEventData eventData)
                 {
                         if (slot == null || _inventory == null)
                                 return;
@@ -79,7 +79,7 @@ namespace TPSBR.UI
                         UpdateDragPosition(eventData);
                 }
 
-                internal void UpdateSlotDrag(PointerEventData eventData)
+                void IUIItemSlotOwner.UpdateSlotDrag(PointerEventData eventData)
                 {
                         if (_dragSource == null)
                                 return;
@@ -87,7 +87,7 @@ namespace TPSBR.UI
                         UpdateDragPosition(eventData);
                 }
 
-                internal void EndSlotDrag(UIItemSlot slot, PointerEventData eventData)
+                void IUIItemSlotOwner.EndSlotDrag(UIItemSlot slot, PointerEventData eventData)
                 {
                         if (_dragSource != slot)
                                 return;
@@ -96,7 +96,7 @@ namespace TPSBR.UI
                         SetDragVisible(false);
                 }
 
-                internal void HandleSlotDrop(UIItemSlot source, UIItemSlot target)
+                void IUIItemSlotOwner.HandleSlotDrop(UIItemSlot source, UIItemSlot target)
                 {
                         if (_inventory == null)
                                 return;

--- a/Assets/TPSBR/UI/Prefabs/GameplayViews/UIInventoryView.prefab
+++ b/Assets/TPSBR/UI/Prefabs/GameplayViews/UIInventoryView.prefab
@@ -30,6 +30,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8667791998921046791}
+  - {fileID: 7032918475623412346}
   m_Father: {fileID: 5456161709449814638}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -146,6 +147,7 @@ MonoBehaviour:
   _closeButton: {fileID: 2012746768402173249}
   _cancelButton: {fileID: 0}
   _inventoryGrid: {fileID: 5632109876543210987}
+  _hotbar: {fileID: 7032918475623412348}
 --- !u!111 &3528502294394753672
 Animation:
   m_ObjectHideFlags: 0
@@ -394,9 +396,482 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 1892fae9dc5a4133a00fe86557d7526c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
+  m_Name:
+  m_EditorClassIdentifier:
   _dragLayer: {fileID: 0}
+--- !u!1 &7032918475623412345
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7032918475623412346}
+  - component: {fileID: 7032918475623412348}
+  m_Layer: 5
+  m_Name: Hotbar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7032918475623412346
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7032918475623412345}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7032918475623412404}
+  - {fileID: 7032918475623412407}
+  - {fileID: 7032918475623412410}
+  - {fileID: 7032918475623412413}
+  m_Father: {fileID: 1051820155323456096}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0}
+  m_AnchorMax: {x: 0.5, y: 0}
+  m_AnchoredPosition: {x: 0, y: 60}
+  m_SizeDelta: {x: 440, y: 120}
+  m_Pivot: {x: 0.5, y: 0}
+--- !u!114 &7032918475623412348
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7032918475623412345}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 92e83c7163ef4e5e8b3c5984c0e9f52b, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+  _dragLayer: {fileID: 0}
+--- !u!1001 &7032918475623412400
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7032918475623412346}
+    m_Modifications:
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -165
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -165
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2816681939503014035, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Name
+      value: HotbarSlot (1)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7650146946688592044, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_TargetGraphic
+      value:
+      objectReference: {fileID: 7032918475623412405}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+--- !u!224 &7032918475623412404 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+  m_PrefabInstance: {fileID: 7032918475623412400}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7032918475623412405 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2666945380867304323, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+  m_PrefabInstance: {fileID: 7032918475623412400}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!1001 &7032918475623412401
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7032918475623412346}
+    m_Modifications:
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -55
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -55
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2816681939503014035, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Name
+      value: HotbarSlot (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7650146946688592044, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_TargetGraphic
+      value:
+      objectReference: {fileID: 7032918475623412408}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+--- !u!224 &7032918475623412407 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+  m_PrefabInstance: {fileID: 7032918475623412401}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7032918475623412408 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2666945380867304323, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+  m_PrefabInstance: {fileID: 7032918475623412401}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!1001 &7032918475623412402
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7032918475623412346}
+    m_Modifications:
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 55
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 55
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2816681939503014035, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Name
+      value: HotbarSlot (3)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7650146946688592044, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_TargetGraphic
+      value:
+      objectReference: {fileID: 7032918475623412411}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+--- !u!224 &7032918475623412410 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+  m_PrefabInstance: {fileID: 7032918475623412402}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7032918475623412411 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2666945380867304323, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+  m_PrefabInstance: {fileID: 7032918475623412402}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
+--- !u!1001 &7032918475623412403
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 7032918475623412346}
+    m_Modifications:
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 100
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 165
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 165
+      objectReference: {fileID: 0}
+    - target: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2816681939503014035, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_Name
+      value: HotbarSlot (4)
+      objectReference: {fileID: 0}
+    - target: {fileID: 7650146946688592044, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+      propertyPath: m_TargetGraphic
+      value:
+      objectReference: {fileID: 7032918475623412414}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+--- !u!224 &7032918475623412413 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 1650781864028813837, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+  m_PrefabInstance: {fileID: 7032918475623412403}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &7032918475623412414 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 2666945380867304323, guid: 2240850c425092947a275dd96f69fc73, type: 3}
+  m_PrefabInstance: {fileID: 7032918475623412403}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name:
+  m_EditorClassIdentifier:
 --- !u!1001 &43215082681018927
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/TSS/WeaponDefinition.cs
+++ b/Assets/TSS/WeaponDefinition.cs
@@ -1,3 +1,4 @@
+using TPSBR;
 using TSS.Data;
 using UnityEngine;
 
@@ -5,6 +6,9 @@ namespace Unity.Template.CompetitiveActionMultiplayer
 {
     public class WeaponDefinition : ItemDefinition
     {
-       
+        [SerializeField]
+        private Weapon _weaponPrefab;
+
+        public Weapon WeaponPrefab => _weaponPrefab;
     }
 }

--- a/Assets/UIItemSlot.cs
+++ b/Assets/UIItemSlot.cs
@@ -7,7 +7,7 @@ namespace TPSBR.UI
 {
     public class UIItemSlot : UIWidget, IBeginDragHandler, IDragHandler, IEndDragHandler, IDropHandler
     {
-        private UIInventoryGrid _owner;
+        private IUIItemSlotOwner _owner;
         private UIButton _button;
         private CanvasGroup _canvasGroup;
         private Image _iconImage;
@@ -37,7 +37,7 @@ namespace TPSBR.UI
             base.OnDeinitialize();
         }
 
-        internal void InitializeSlot(UIInventoryGrid owner, int index)
+        internal void InitializeSlot(IUIItemSlotOwner owner, int index)
         {
             _owner = owner;
             Index = index;
@@ -127,6 +127,8 @@ namespace TPSBR.UI
 
             _owner.HandleSlotDrop(sourceSlot, this);
         }
+
+        internal IUIItemSlotOwner Owner => _owner;
 
         private void EnsureCanvasGroup()
         {


### PR DESCRIPTION
## Summary
- add a reusable item-slot owner interface and hotbar widget with drag visuals
- extend the inventory to store weapon pickups, emit hotbar change events, and assign slots from the UI
- update the gameplay inventory view and prefab to include a four-slot hotbar and simplify number-key weapon selection

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e4563099788326aae13419783a1e51