### PR TITLE
Refactor weapon slot handling to use weapon size

### DIFF
--- a/Assets/TPSBR/Prefabs/Pickups/PistolAmmoPickup.prefab
+++ b/Assets/TPSBR/Prefabs/Pickups/PistolAmmoPickup.prefab
@@ -334,7 +334,7 @@ MonoBehaviour:
   _interactionName: Pistol ammo
   _interactionDescription: Adds 24 rounds
   _startBehaviour: 1
-  _weaponSlot: 1
+  _weaponSize: 1
   _amount: 24
 --- !u!65 &4044552468348988159
 BoxCollider:

--- a/Assets/TPSBR/Prefabs/Pickups/RifleAmmoPickup.prefab
+++ b/Assets/TPSBR/Prefabs/Pickups/RifleAmmoPickup.prefab
@@ -17,7 +17,7 @@ PrefabInstance:
       value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 1214334607122330860, guid: 515d0a7122c2eca4cb0841021a46116a, type: 3}
-      propertyPath: _weaponSlot
+      propertyPath: _weaponSize
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1214334607122330860, guid: 515d0a7122c2eca4cb0841021a46116a, type: 3}

--- a/Assets/TPSBR/Prefabs/Weapons/ExplosiveGrenadeWeapon.prefab
+++ b/Assets/TPSBR/Prefabs/Weapons/ExplosiveGrenadeWeapon.prefab
@@ -131,7 +131,7 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 4277888676774824892, guid: ec623b358d5c4024285c5bbe37de2b89, type: 3}
     - target: {fileID: 5660633326291460765, guid: 13b0c1881e42b7244a39d267e8307c74, type: 3}
-      propertyPath: _weaponSlot
+      propertyPath: _weaponSize
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5660633326291460765, guid: 13b0c1881e42b7244a39d267e8307c74, type: 3}

--- a/Assets/TPSBR/Prefabs/Weapons/FlashGrenadeWeapon.prefab
+++ b/Assets/TPSBR/Prefabs/Weapons/FlashGrenadeWeapon.prefab
@@ -119,7 +119,7 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1804314541318750671, guid: ca3eb738d4060ac43a92ab93f5a88392, type: 3}
     - target: {fileID: 5660633326291460765, guid: 13b0c1881e42b7244a39d267e8307c74, type: 3}
-      propertyPath: _weaponSlot
+      propertyPath: _weaponSize
       value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 5660633326291460765, guid: 13b0c1881e42b7244a39d267e8307c74, type: 3}

--- a/Assets/TPSBR/Prefabs/Weapons/GrenadeWeaponBase.prefab
+++ b/Assets/TPSBR/Prefabs/Weapons/GrenadeWeaponBase.prefab
@@ -232,7 +232,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _weaponID: Weapons.Grenade
-  _weaponSlot: 5
+  _weaponSize: 5
   _validOnlyWithAmmo: 1
   _leftHandTarget: {fileID: 0}
   _hitType: 3

--- a/Assets/TPSBR/Prefabs/Weapons/PistolBase.prefab
+++ b/Assets/TPSBR/Prefabs/Weapons/PistolBase.prefab
@@ -330,7 +330,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _weaponID: Weapons.Pistol
-  _weaponSlot: 1
+  _weaponSize: 1
   _validOnlyWithAmmo: 0
   _leftHandTarget: {fileID: 4491110720844014620}
   _hitType: 1

--- a/Assets/TPSBR/Prefabs/Weapons/RifleBase.prefab
+++ b/Assets/TPSBR/Prefabs/Weapons/RifleBase.prefab
@@ -277,7 +277,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _weaponID: Weapons.Rifle
-  _weaponSlot: 2
+  _weaponSize: 2
   _validOnlyWithAmmo: 0
   _leftHandTarget: {fileID: 7131331527089721130}
   _hitType: 2

--- a/Assets/TPSBR/Prefabs/Weapons/SmokeGrenadeWeapon.prefab
+++ b/Assets/TPSBR/Prefabs/Weapons/SmokeGrenadeWeapon.prefab
@@ -119,7 +119,7 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 9105724515599064402, guid: f58cf669b1f324f448da4b73ca39b7d4, type: 3}
     - target: {fileID: 5660633326291460765, guid: 13b0c1881e42b7244a39d267e8307c74, type: 3}
-      propertyPath: _weaponSlot
+      propertyPath: _weaponSize
       value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 5660633326291460765, guid: 13b0c1881e42b7244a39d267e8307c74, type: 3}

--- a/Assets/TPSBR/Prefabs/Weapons/SniperBase.prefab
+++ b/Assets/TPSBR/Prefabs/Weapons/SniperBase.prefab
@@ -277,7 +277,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _weaponID: Weapons.Sniper
-  _weaponSlot: 2
+  _weaponSize: 2
   _validOnlyWithAmmo: 0
   _leftHandTarget: {fileID: 7131331527089721130}
   _hitType: 8

--- a/Assets/TPSBR/Prefabs/Weapons/StaffBase.prefab
+++ b/Assets/TPSBR/Prefabs/Weapons/StaffBase.prefab
@@ -283,7 +283,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _weaponDefinition: {fileID: 11400000, guid: 7097084c92398ea4d941052422e26ef8, type: 2}
-  _weaponSlot: 1
+  _weaponSize: 3
   _validOnlyWithAmmo: 0
   _leftHandTarget: {fileID: 0}
   _hitType: 0

--- a/Assets/TPSBR/Prefabs/Weapons/Unarmed.prefab
+++ b/Assets/TPSBR/Prefabs/Weapons/Unarmed.prefab
@@ -256,7 +256,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _weaponID: Weapons.Unarmed
-  _weaponSlot: 0
+  _weaponSize: 0
   _validOnlyWithAmmo: 0
   _leftHandTarget: {fileID: 0}
   _hitType: 0

--- a/Assets/TPSBR/Scripts/Gameplay/Agent/Agent.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Agent/Agent.cs
@@ -280,15 +280,15 @@ namespace TPSBR
 			}
 		}
 
-		private void TryFire(bool attack, bool hold)
-		{
-			var currentWeapon = _inventory.CurrentWeapon;
-			if (currentWeapon is ThrowableWeapon && currentWeapon.WeaponSlot == _inventory.CurrentWeaponSlot)
-			{
-				// Fire is handled form the grenade animation state itself
-				_character.AnimationController.ProcessThrow(attack, hold);
-				return;
-			}
+                private void TryFire(bool attack, bool hold)
+                {
+                        var currentWeapon = _inventory.CurrentWeapon;
+                        if (currentWeapon is ThrowableWeapon && _inventory.CurrentWeaponSize == WeaponSize.Throwable)
+                        {
+                                // Fire is handled form the grenade animation state itself
+                                _character.AnimationController.ProcessThrow(attack, hold);
+                                return;
+                        }
 
 			if (hold == false)
 				return;

--- a/Assets/TPSBR/Scripts/Gameplay/Agent/Character/States/DeadState.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Agent/Character/States/DeadState.cs
@@ -11,13 +11,19 @@ namespace TPSBR
 
 		// MultiClipState INTERFACE
 
-		protected override int GetClipID()
-		{
-			if (_inventory.CurrentWeaponSlot > 2)
-				return 1; // For grenades we use pistol set
+                protected override int GetClipID()
+                {
+                        WeaponSize currentSize = _inventory.CurrentWeaponSize;
+                        int stanceIndex = currentSize.ToStanceIndex();
 
-			return Mathf.Max(0, _inventory.CurrentWeaponSlot);
-		}
+                        int clipCount = Nodes != null ? Nodes.Length : 0;
+                        if (clipCount > 0)
+                        {
+                                stanceIndex = Mathf.Clamp(stanceIndex, 0, clipCount - 1);
+                        }
+
+                        return Mathf.Max(0, stanceIndex);
+                }
 
 		// AnimationState INTERFACE
 

--- a/Assets/TPSBR/Scripts/Gameplay/Agent/Character/States/LookState.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Agent/Character/States/LookState.cs
@@ -123,19 +123,21 @@ namespace TPSBR
 			_mixer.SetInputWeight(clipIndex, 1.0f);
 		}
 
-		private int GetSetID()
-		{
-			int currentWeaponSlot = _inventory.CurrentWeaponSlot;
-			if (currentWeaponSlot > 2)
-			{
-				currentWeaponSlot = 1; // For grenades we use pistol set
-			}
+                private int GetSetID()
+                {
+                        WeaponSize currentSize = _inventory.CurrentWeaponSize;
+                        int stanceIndex = currentSize.ToStanceIndex();
 
-			if (currentWeaponSlot < 0)
-				return -1;
+                        if (_sets == null || _sets.Length == 0)
+                                return -1;
 
-			return currentWeaponSlot;
-		}
+                        if (stanceIndex >= _sets.Length)
+                        {
+                                stanceIndex = Mathf.Clamp(_sets.Length - 1, 0, int.MaxValue);
+                        }
+
+                        return stanceIndex;
+                }
 
 		[Serializable]
 		private sealed class LookSet

--- a/Assets/TPSBR/Scripts/Gameplay/Agent/Character/States/MoveState.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Agent/Character/States/MoveState.cs
@@ -67,19 +67,13 @@ namespace TPSBR
 			return 1.0f;
 		}
 
-		public override int GetSetID()
-		{
-			int currentWeaponSlot = _inventory.CurrentWeaponSlot;
-			if (currentWeaponSlot > 2)
-			{
-				currentWeaponSlot = 1; // For grenades we use pistol set
-			}
+                public override int GetSetID()
+                {
+                        WeaponSize currentSize = _inventory.CurrentWeaponSize;
+                        int stanceIndex = currentSize.ToStanceIndex();
 
-			if (currentWeaponSlot < 0)
-				return 0;
-
-			return currentWeaponSlot;
-		}
+                        return Mathf.Max(0, stanceIndex);
+                }
 
 		// AnimationState INTERFACE
 
@@ -261,16 +255,18 @@ namespace TPSBR
 			return Mathf.Lerp(nodes[fromNodeIndex].Position.magnitude, nodes[toNodeIndex].Position.magnitude, alpha);
 		}
 
-		private float GetMultiplier()
-		{
-			switch (_inventory.CurrentWeaponSlot)
-			{
-				case 0: { return 1.0f;  }
-				case 1: { return 0.95f; }
-				case 2: { return 0.9f;  }
-			}
+                private float GetMultiplier()
+                {
+                        switch (_inventory.CurrentWeaponSize)
+                        {
+                                case WeaponSize.Unarmed:   return 1.0f;
+                                case WeaponSize.Light:     return 0.95f;
+                                case WeaponSize.Throwable: return 0.95f;
+                                case WeaponSize.Heavy:     return 0.9f;
+                                case WeaponSize.Staff:     return 0.92f;
+                        }
 
-			return 0.95f;
-		}
+                        return 0.95f;
+                }
 	}
 }

--- a/Assets/TPSBR/Scripts/Gameplay/Agent/Character/States/ShootState.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Agent/Character/States/ShootState.cs
@@ -17,19 +17,16 @@ namespace TPSBR
 
 		// MultiClipState INTERFACE
 
-		protected override int GetClipID()
-		{
-			int currentWeaponSlot = _inventory.CurrentWeaponSlot;
-			if (currentWeaponSlot > 2)
-			{
-				currentWeaponSlot = 1; // For grenades we use pistol set
-			}
+                protected override int GetClipID()
+                {
+                        WeaponSize currentSize = _inventory.CurrentWeaponSize;
+                        int stanceIndex = currentSize.ToStanceIndex();
 
-			if (currentWeaponSlot < 0)
-				return 0;
+                        int setCount = Nodes != null && Nodes.Length > 0 ? Mathf.Max(1, Nodes.Length / 2) : 1;
+                        stanceIndex = Mathf.Clamp(stanceIndex, 0, setCount - 1);
 
-			return currentWeaponSlot * 2 + 1;
-		}
+                        return stanceIndex * 2 + 1;
+                }
 
 		// AnimationState INTERFACE
 

--- a/Assets/TPSBR/Scripts/Gameplay/Agent/Character/States/TurnState.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Agent/Character/States/TurnState.cs
@@ -173,19 +173,16 @@ namespace TPSBR
 
 		// PRIVATE METHODS
 
-		private int GetClipID()
-		{
-			int currentWeaponSlot = _inventory.CurrentWeaponSlot;
-			if (currentWeaponSlot > 2)
-			{
-				currentWeaponSlot = 1; // For grenades we use pistol set
-			}
+                private int GetClipID()
+                {
+                        WeaponSize currentSize = _inventory.CurrentWeaponSize;
+                        int stanceIndex = currentSize.ToStanceIndex();
 
-			if (currentWeaponSlot < 0)
-				return 0;
+                        int setCount = _nodes != null && _nodes.Length > 0 ? Mathf.Max(1, _nodes.Length / 3) : 1;
+                        stanceIndex = Mathf.Clamp(stanceIndex, 0, setCount - 1);
 
-			return currentWeaponSlot * 3;
-		}
+                        return stanceIndex * 3;
+                }
 
 		private void InterpolateAnimationTime(AnimationInterpolationInfo interpolationInfo)
 		{

--- a/Assets/TPSBR/Scripts/Gameplay/Interactions/Pickups/AmmoPickup.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Interactions/Pickups/AmmoPickup.cs
@@ -6,8 +6,8 @@ namespace TPSBR
 	{
 		// PRIVATE MEMBERS
 
-		[SerializeField]
-		private int _weaponSlot = 1;
+                [SerializeField]
+                private WeaponSize _weaponSize = WeaponSize.Light;
 		[SerializeField]
 		private int _amount = 50;
 
@@ -21,7 +21,7 @@ namespace TPSBR
 				return false;
 			}
 
-			return weapons.AddAmmo(_weaponSlot, _amount, out result);
-		}
-	}
+                        return weapons.AddAmmo(_weaponSize, _amount, out result);
+                }
+        }
 }

--- a/Assets/TPSBR/Scripts/Gameplay/Weapons/Weapon.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Weapons/Weapon.cs
@@ -10,7 +10,6 @@ namespace TPSBR
 
         public int WeaponID => _weaponDefinition.ID;
         public WeaponDefinition Definition => _weaponDefinition;
-        public int WeaponSlot => _weaponSlot;
         public Transform LeftHandTarget => _leftHandTarget;
         public DynamicPickup PickupPrefab => _pickupPrefab;
         public EHitType HitType => _hitType;
@@ -23,12 +22,12 @@ namespace TPSBR
         public bool IsArmed => _isArmed;
         public NetworkObject Owner => _owner;
         public Character Character => _character;
+        public WeaponSize Size => _weaponSize;
 
         // PRIVATE MEMBERS
 
         [SerializeField] private WeaponDefinition _weaponDefinition;
-
-        [SerializeField] private int _weaponSlot;
+        [SerializeField] private WeaponSize _weaponSize = WeaponSize.Unarmed;
         [SerializeField] private bool _validOnlyWithAmmo;
         [SerializeField] private Transform _leftHandTarget;
         [SerializeField] private EHitType _hitType;
@@ -155,11 +154,6 @@ namespace TPSBR
         public virtual bool CanFireToPosition(Vector3 firePosition, ref Vector3 targetPosition, LayerMask hitMask)
         {
             return true;
-        }
-
-        public void OverrideWeaponSlot(int slot)
-        {
-            _weaponSlot = slot;
         }
 
         // NetworkBehaviour INTERFACE

--- a/Assets/TPSBR/Scripts/Gameplay/Weapons/WeaponSize.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Weapons/WeaponSize.cs
@@ -1,0 +1,11 @@
+namespace TPSBR
+{
+    public enum WeaponSize
+    {
+        Unarmed = 0,
+        Light = 1,
+        Heavy = 2,
+        Staff = 3,
+        Throwable = 5,
+    }
+}

--- a/Assets/TPSBR/Scripts/Gameplay/Weapons/WeaponSize.cs.meta
+++ b/Assets/TPSBR/Scripts/Gameplay/Weapons/WeaponSize.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cb5c8f0c2e74d1e9b3b94aa2fbe2a36
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/TPSBR/Scripts/Gameplay/Weapons/WeaponSizeExtensions.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Weapons/WeaponSizeExtensions.cs
@@ -1,0 +1,31 @@
+namespace TPSBR
+{
+    public static class WeaponSizeExtensions
+    {
+        public static int ToStanceIndex(this WeaponSize size)
+        {
+            return size switch
+            {
+                WeaponSize.Unarmed => 0,
+                WeaponSize.Light => 1,
+                WeaponSize.Throwable => 1,
+                WeaponSize.Heavy => 2,
+                WeaponSize.Staff => 3,
+                _ => 0,
+            };
+        }
+
+        public static string ToDisplayClass(this WeaponSize size)
+        {
+            return size switch
+            {
+                WeaponSize.Unarmed => "UNARMED",
+                WeaponSize.Light => "SIDEARM",
+                WeaponSize.Heavy => "PRIMARY",
+                WeaponSize.Staff => "STAFF",
+                WeaponSize.Throwable => "THROWABLE",
+                _ => "UNARMED",
+            };
+        }
+    }
+}

--- a/Assets/TPSBR/Scripts/Gameplay/Weapons/WeaponSizeExtensions.cs.meta
+++ b/Assets/TPSBR/Scripts/Gameplay/Weapons/WeaponSizeExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4cf10eae5f7346ffb3b92f2247f2cf0f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- remove weapon slot serialization in favour of a new WeaponSize enum and extension helpers
- rewrite inventory, pickup, animation and UI systems to derive behaviour from weapon size instead of weapon slots
- update weapon and ammo prefabs to store their weapon size values and ensure size-aware hotbar logic

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_b_68e54eb2bb5883268ff576c1a0f1bfeb