### PR TITLE
Highlight selected hotbar slot

### DIFF
--- a/Assets/TPSBR/Scenes/GameplayUI.unity
+++ b/Assets/TPSBR/Scenes/GameplayUI.unity
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:11698a7dce17f7dddbaa1d0a76a276284b44af8bcac5739ad041a6635ae9acf4
-size 202069
+oid sha256:40fd154e4c5701c3185e6e1aaaca5e68359b9861f7ff421ddfaad4324d72fb94
+size 202627

--- a/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
+++ b/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
@@ -13,6 +13,7 @@ namespace TPSBR.UI
         [SerializeField] private UIButton _cancelButton;
         [SerializeField] private UIInventoryGrid _inventoryGrid;
         [SerializeField] private UIHotbar _hotbar;
+        [SerializeField] private Color _selectedHotbarColor = Color.white;
 
         private bool _menuVisible;
         private Agent _boundAgent;
@@ -54,6 +55,11 @@ namespace TPSBR.UI
             if (_hotbar == null)
             {
                 _hotbar = GetComponentInChildren<UIHotbar>(true);
+            }
+
+            if (_hotbar != null)
+            {
+                _hotbar.SetSelectedColor(_selectedHotbarColor);
             }
 
             if (_cancelButton != null)

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
@@ -16,6 +16,8 @@ namespace TPSBR.UI
         private RectTransform _dragIcon;
         private Image _dragImage;
         private CanvasGroup _dragCanvasGroup;
+        private Color _selectionColor = Color.white;
+        private int _lastSelectedSlot = -1;
 
         protected override void OnInitialize()
         {
@@ -27,6 +29,8 @@ namespace TPSBR.UI
             {
                 _slots[i].InitializeSlot(this, i);
             }
+
+            UpdateSelection(true);
         }
 
         protected override void OnDeinitialize()
@@ -67,6 +71,24 @@ namespace TPSBR.UI
 
             SetDragVisible(false);
             _dragSource = null;
+
+            UpdateSelection(true);
+        }
+
+        internal void SetSelectedColor(Color color)
+        {
+            if (_selectionColor == color)
+                return;
+
+            _selectionColor = color;
+            UpdateSelection(true);
+        }
+
+        protected override void OnTick()
+        {
+            base.OnTick();
+
+            UpdateSelection();
         }
 
         void IUIItemSlotOwner.BeginSlotDrag(UIItemSlot slot, PointerEventData eventData)
@@ -143,6 +165,34 @@ namespace TPSBR.UI
             }
 
             _slots[index].SetItem(weapon.Icon, 1);
+        }
+
+        private void UpdateSelection(bool forceUpdate = false)
+        {
+            if (_slots == null || _slots.Length == 0)
+                return;
+
+            int selectedSlot = -1;
+
+            if (_inventory != null)
+            {
+                int inventorySlot = _inventory.CurrentWeaponSlot;
+                if (inventorySlot > 0)
+                {
+                    selectedSlot = inventorySlot - 1;
+                }
+            }
+
+            if (forceUpdate == false && selectedSlot == _lastSelectedSlot)
+                return;
+
+            _lastSelectedSlot = selectedSlot;
+
+            for (int i = 0; i < _slots.Length; i++)
+            {
+                bool isSelected = i == selectedSlot;
+                _slots[i].SetSelected(isSelected, _selectionColor);
+            }
         }
 
         private void EnsureDragVisual()

--- a/Assets/TPSBR/UI/Prefabs/Widgets/UIItemSlot.prefab
+++ b/Assets/TPSBR/UI/Prefabs/Widgets/UIItemSlot.prefab
@@ -91,6 +91,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e3f560273b4805a4d8b805bbe6796fb8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _backgroundImage: {fileID: 5743454164759915271}
 --- !u!114 &6846514888227408305
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/TPSBR/UI/UIItemSlot.cs
+++ b/Assets/TPSBR/UI/UIItemSlot.cs
@@ -13,6 +13,8 @@ namespace TPSBR.UI
         private static readonly List<UIItemSlot> _allSlots = new List<UIItemSlot>();
         private static UIItemSlot _activeDragSlot;
 
+        [SerializeField] private Image _backgroundImage;
+
         private IUIItemSlotOwner _owner;
         private UIButton _button;
         private CanvasGroup _canvasGroup;
@@ -21,6 +23,8 @@ namespace TPSBR.UI
         private Sprite _iconSprite;
         private int _quantity;
         private bool _isDragging;
+        private Color _defaultBackgroundColor;
+        private bool _defaultBackgroundColorCached;
 
         public int Index { get; private set; } = -1;
         public RectTransform SlotRectTransform => RectTransform;
@@ -34,6 +38,8 @@ namespace TPSBR.UI
 
             _button = GetComponent<UIButton>();
             EnsureCanvasGroup();
+
+            CacheDefaultBackgroundColor();
 
             if (_allSlots.Contains(this) == false)
             {
@@ -166,6 +172,16 @@ namespace TPSBR.UI
 
         internal IUIItemSlotOwner Owner => _owner;
 
+        internal void SetSelected(bool selected, Color selectedColor)
+        {
+            if (_backgroundImage == null)
+                return;
+
+            CacheDefaultBackgroundColor();
+
+            _backgroundImage.color = selected ? selectedColor : _defaultBackgroundColor;
+        }
+
         private void EnsureCanvasGroup()
         {
             if (_canvasGroup != null)
@@ -176,6 +192,15 @@ namespace TPSBR.UI
             {
                 _canvasGroup = gameObject.AddComponent<CanvasGroup>();
             }
+        }
+
+        private void CacheDefaultBackgroundColor()
+        {
+            if (_backgroundImage == null || _defaultBackgroundColorCached == true)
+                return;
+
+            _defaultBackgroundColor = _backgroundImage.color;
+            _defaultBackgroundColorCached = true;
         }
 
         private void EnsureIconImage()


### PR DESCRIPTION
## Summary
- add a serialized hotbar selection color on the gameplay inventory and forward it to the hotbar widget
- cache default background colors on hotbar item slots and toggle their highlight based on the equipped weapon slot

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_b_68e5ac00c7e4832686e2f853a3b635ab