### PR TITLE
Fix hotbar drag icon alignment with cursor

### DIFF
--- a/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
@@ -237,11 +237,11 @@ namespace TPSBR.UI
             if (_dragIcon == null)
                 return;
 
-            RectTransform canvasRect = SceneUI.Canvas.transform as RectTransform;
-            if (canvasRect == null)
+            RectTransform referenceRect = _dragIcon.parent as RectTransform;
+            if (referenceRect == null)
                 return;
 
-            if (RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRect, eventData.position, SceneUI.Canvas.worldCamera, out Vector2 localPoint))
+            if (RectTransformUtility.ScreenPointToLocalPointInRectangle(referenceRect, eventData.position, SceneUI.Canvas.worldCamera, out Vector2 localPoint))
             {
                 _dragIcon.localPosition = localPoint;
             }

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
@@ -174,11 +174,11 @@ namespace TPSBR.UI
                         if (_dragIcon == null)
                                 return;
 
-                        RectTransform canvasRect = SceneUI.Canvas.transform as RectTransform;
-                        if (canvasRect == null)
+                        RectTransform referenceRect = _dragIcon.parent as RectTransform;
+                        if (referenceRect == null)
                                 return;
 
-                        if (RectTransformUtility.ScreenPointToLocalPointInRectangle(canvasRect, eventData.position, SceneUI.Canvas.worldCamera, out Vector2 localPoint))
+                        if (RectTransformUtility.ScreenPointToLocalPointInRectangle(referenceRect, eventData.position, SceneUI.Canvas.worldCamera, out Vector2 localPoint))
                         {
                                 _dragIcon.localPosition = localPoint;
                         }


### PR DESCRIPTION
## Summary
- adjust drag icon position calculations to respect the drag layer transform
- ensure both hotbar and inventory drag visuals follow the cursor precisely

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_b_68e5b2fe24288326b14698ca3f9d3fff