### PR TITLE
Allow storing hotbar weapons back into the inventory

### DIFF
--- a/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
@@ -104,10 +104,22 @@ namespace TPSBR.UI
                         SetDragVisible(false);
                         _dragSource = null;
 
-                        if (source.Index == target.Index)
+                        if (source == null || target == null)
                                 return;
 
-                        _inventory.RequestMoveItem(source.Index, target.Index);
+                        if (ReferenceEquals(source.Owner, this) == true)
+                        {
+                                if (source.Index == target.Index)
+                                        return;
+
+                                _inventory.RequestMoveItem(source.Index, target.Index);
+                                return;
+                        }
+
+                        if (source.Owner is UIHotbar)
+                        {
+                                _inventory.RequestStoreHotbar(source.Index, target.Index);
+                        }
                 }
 
                 private void OnItemSlotChanged(int index, InventorySlot slot)


### PR DESCRIPTION
## Summary
- add inventory handling for drops coming from the hotbar UI
- implement server-side request and RPC to move weapons from the hotbar into an inventory slot
- ensure hotbar state updates when removing the active weapon and despawn the stored weapon object

## Testing
- not run (Unity project)


------
https://chatgpt.com/codex/tasks/task_b_68e5b370e9a88326acaad06da8745998