### PR TITLE
Add world drop support for dragged inventory and hotbar items

### DIFF
--- a/Assets/TPSBR/Prefabs/Agents/Wizard.prefab
+++ b/Assets/TPSBR/Prefabs/Agents/Wizard.prefab
@@ -615,6 +615,10 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 8019168302190258968, guid: c17b47fcacdfc8d4b80809005a2b2555, type: 3}
+      propertyPath: _inventoryItemPickupPrefab
+      value: 
+      objectReference: {fileID: 483920102938475611, guid: 892c06a7028b40b585f94a6ffd3f8fb0, type: 3}
+    - target: {fileID: 8019168302190258968, guid: c17b47fcacdfc8d4b80809005a2b2555, type: 3}
       propertyPath: _slots.Array.data[0].Active
       value: 
       objectReference: {fileID: 6388543282259232068}

--- a/Assets/TPSBR/Scripts/Gameplay/Weapons/Inventory.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Weapons/Inventory.cs
@@ -108,6 +108,10 @@ namespace TPSBR
         [SerializeField] private WeaponSizeSlot[] _weaponSizeSlots;
         [SerializeField] private Weapon[] _initialWeapons;
         [SerializeField] private LayerMask _hitMask;
+        [SerializeField] private InventoryItemPickupProvider _inventoryItemPickupPrefab;
+        [SerializeField] private float _itemDropForwardOffset = 1.5f;
+        [SerializeField] private float _itemDropUpOffset = 0.35f;
+        [SerializeField] private float _itemDropImpulse = 3f;
 
         [Header("Audio")] [SerializeField] private Transform _fireAudioEffectsRoot;
 
@@ -200,6 +204,37 @@ namespace TPSBR
             else
             {
                 RPC_RequestSwapHotbar((byte)fromIndex, (byte)toIndex);
+            }
+        }
+
+        public void RequestDropInventoryItem(int inventoryIndex)
+        {
+            if (inventoryIndex < 0 || inventoryIndex >= _items.Length)
+                return;
+
+            if (HasStateAuthority == true)
+            {
+                DropInventoryItem(inventoryIndex);
+            }
+            else
+            {
+                RPC_RequestDropInventoryItem((byte)inventoryIndex);
+            }
+        }
+
+        public void RequestDropHotbar(int hotbarIndex)
+        {
+            int weaponSlot = hotbarIndex + 1;
+            if (weaponSlot <= 0 || weaponSlot >= _hotbar.Length)
+                return;
+
+            if (HasStateAuthority == true)
+            {
+                DropWeapon(weaponSlot);
+            }
+            else
+            {
+                RPC_RequestDropHotbar((byte)weaponSlot);
             }
         }
 
@@ -715,6 +750,18 @@ namespace TPSBR
             SwapHotbar(fromIndex, toIndex);
         }
 
+        [Rpc(RpcSources.InputAuthority, RpcTargets.StateAuthority)]
+        private void RPC_RequestDropInventoryItem(byte inventoryIndex)
+        {
+            DropInventoryItem(inventoryIndex);
+        }
+
+        [Rpc(RpcSources.InputAuthority, RpcTargets.StateAuthority)]
+        private void RPC_RequestDropHotbar(byte weaponSlot)
+        {
+            DropWeapon(weaponSlot);
+        }
+
         private byte AddItemInternal(ItemDefinition definition, byte quantity, NetworkString<_32> configurationHash)
         {
             ushort maxStack = ItemDefinition.GetMaxStack(definition.ID);
@@ -932,6 +979,29 @@ namespace TPSBR
             RefreshWeapons();
         }
 
+        private void DropInventoryItem(int index)
+        {
+            if (index < 0 || index >= _items.Length)
+                return;
+
+            var slot = _items[index];
+            if (slot.IsEmpty == true)
+                return;
+
+            var definition = slot.GetDefinition();
+            if (definition == null)
+                return;
+
+            byte quantity = slot.Quantity;
+            if (quantity == 0)
+                return;
+
+            if (RemoveInventoryItemInternal(index, quantity) == false)
+                return;
+
+            SpawnInventoryItemPickup(definition, quantity);
+        }
+
         private bool RemoveInventoryItemInternal(int index, byte quantity)
         {
             if (index < 0 || index >= _items.Length)
@@ -1132,9 +1202,14 @@ namespace TPSBR
 
     private void DropWeapon(int weaponSlot)
     {
+        if (weaponSlot <= 0 || weaponSlot >= _hotbar.Length)
+            return;
+
         var weapon = _hotbar[weaponSlot];
         if (weapon == null)
             return;
+
+        var definition = weapon.Definition;
 
         weapon.Deinitialize(Object);
 
@@ -1155,6 +1230,11 @@ namespace TPSBR
         if (weapon != null && weapon.Object != null)
         {
             Runner.Despawn(weapon.Object);
+        }
+
+        if (definition != null)
+        {
+            SpawnInventoryItemPickup(definition, 1);
         }
     }
 
@@ -1301,6 +1381,64 @@ namespace TPSBR
         else
         {
             _weaponDefinitionsBySlot.Remove(index);
+        }
+    }
+
+    private void SpawnInventoryItemPickup(ItemDefinition definition, byte quantity)
+    {
+        if (HasStateAuthority == false)
+            return;
+
+        if (_inventoryItemPickupPrefab == null)
+            return;
+
+        if (definition == null || quantity == 0)
+            return;
+
+        Vector3 forward = transform.forward;
+        Vector3 origin = transform.position;
+
+        if (_character != null)
+        {
+            var characterTransform = _character.transform;
+            origin = characterTransform.position;
+            forward = characterTransform.forward;
+        }
+
+        forward.y = 0f;
+        if (forward.sqrMagnitude < 0.0001f)
+        {
+            forward = transform.forward;
+            forward.y = 0f;
+        }
+
+        if (forward.sqrMagnitude < 0.0001f)
+        {
+            forward = Vector3.forward;
+        }
+
+        forward.Normalize();
+
+        Vector3 randomOffset = new Vector3(UnityEngine.Random.Range(-0.25f, 0.25f), 0f, UnityEngine.Random.Range(-0.25f, 0.25f));
+        Vector3 spawnPosition = origin + forward * _itemDropForwardOffset + Vector3.up * _itemDropUpOffset + randomOffset;
+        Quaternion rotation = Quaternion.LookRotation(forward, Vector3.up);
+
+        var provider = Runner.Spawn(_inventoryItemPickupPrefab, spawnPosition, rotation);
+        if (provider == null)
+            return;
+
+        provider.Initialize(definition, quantity);
+
+        var rigidbody = provider.GetComponent<Rigidbody>();
+        if (rigidbody != null && _itemDropImpulse > 0f)
+        {
+            Vector3 impulseDirection = (forward + Vector3.up * 0.5f).normalized;
+            if (impulseDirection.sqrMagnitude < 0.0001f)
+            {
+                impulseDirection = Vector3.up;
+            }
+
+            rigidbody.AddForce(impulseDirection * _itemDropImpulse, ForceMode.VelocityChange);
         }
     }
 

--- a/Assets/TPSBR/Scripts/UI/Widgets/IUIItemSlotOwner.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/IUIItemSlotOwner.cs
@@ -8,5 +8,6 @@ namespace TPSBR.UI
         void UpdateSlotDrag(PointerEventData eventData);
         void EndSlotDrag(UIItemSlot slot, PointerEventData eventData);
         void HandleSlotDrop(UIItemSlot source, UIItemSlot target);
+        void HandleSlotDropOutside(UIItemSlot slot, PointerEventData eventData);
     }
 }

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
@@ -141,6 +141,14 @@ namespace TPSBR.UI
             }
         }
 
+        void IUIItemSlotOwner.HandleSlotDropOutside(UIItemSlot slot, PointerEventData eventData)
+        {
+            if (_inventory == null || slot == null)
+                return;
+
+            _inventory.RequestDropHotbar(slot.Index);
+        }
+
         private void OnHotbarSlotChanged(int index, Weapon weapon)
         {
             int slotIndex = index - 1;

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
@@ -110,6 +110,14 @@ namespace TPSBR.UI
                         _inventory.RequestMoveItem(source.Index, target.Index);
                 }
 
+                void IUIItemSlotOwner.HandleSlotDropOutside(UIItemSlot slot, PointerEventData eventData)
+                {
+                        if (_inventory == null || slot == null)
+                                return;
+
+                        _inventory.RequestDropInventoryItem(slot.Index);
+                }
+
                 private void OnItemSlotChanged(int index, InventorySlot slot)
                 {
                         UpdateSlot(index, slot);

--- a/Assets/TPSBR/UI/UIItemSlot.cs
+++ b/Assets/TPSBR/UI/UIItemSlot.cs
@@ -146,7 +146,13 @@ namespace TPSBR.UI
                 return;
 
             var targetSlot = FindDropTarget(eventData);
-            if (targetSlot == null || targetSlot == this)
+            if (targetSlot == null)
+            {
+                _owner?.HandleSlotDropOutside(this, eventData);
+                return;
+            }
+
+            if (targetSlot == this)
                 return;
 
             var targetOwner = targetSlot.Owner;


### PR DESCRIPTION
## Summary
- allow UI item slots to signal when a drag ends outside of another slot
- request inventory and hotbar drops that spawn pickup prefabs in front of the character
- ensure dropped weapons and items become world pickups with configurable offsets and impulse

## Testing
- not run (Unity project, tests not run in container)


------
https://chatgpt.com/codex/tasks/task_b_68e5b3586d008326ba7b295fa5428a10