### PR TITLE
Add inventory item details panel and selection highlighting

### DIFF
--- a/Assets/TPSBR/Scripts/Gameplay/Weapons/Weapon.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Weapons/Weapon.cs
@@ -16,6 +16,10 @@ namespace TPSBR
         public string DisplayName => _displayName;
         public string NameShortcut => _nameShortcut;
         public Sprite Icon => _weaponDefinition.IconSprite;
+        public virtual string GetDescription()
+        {
+            return _description;
+        }
         public bool ValidOnlyWithAmmo => _validOnlyWithAmmo;
         public bool IsInitialized => _isInitialized;
         public bool IsArmed => _isArmed;
@@ -33,6 +37,7 @@ namespace TPSBR
         [SerializeField] private float _aimFOV;
 
         [Header("Pickup")] [SerializeField] private string _displayName;
+        [SerializeField, TextArea] private string _description;
 
         [SerializeField, Tooltip("Up to 4 letter name shown in thumbnail")]
         private string _nameShortcut;

--- a/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
+++ b/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using TSS.Data;
 
 namespace TPSBR.UI
 {
@@ -14,6 +15,9 @@ namespace TPSBR.UI
         [SerializeField] private UIInventoryGrid _inventoryGrid;
         [SerializeField] private UIHotbar _hotbar;
         [SerializeField] private Color _selectedHotbarColor = Color.white;
+        [SerializeField] private Color _selectedInventorySlotColor = Color.white;
+        [SerializeField] private Color _selectedHotbarSlotColor = Color.white;
+        [SerializeField] private UIInventoryDetailsPanel _detailsPanel;
 
         private bool _menuVisible;
         private Agent _boundAgent;
@@ -60,23 +64,35 @@ namespace TPSBR.UI
             if (_hotbar != null)
             {
                 _hotbar.SetSelectedColor(_selectedHotbarColor);
+                _hotbar.SetSelectionHighlightColor(_selectedHotbarSlotColor);
+                _hotbar.ItemSelected += OnHotbarItemSelected;
+            }
+
+            if (_inventoryGrid != null)
+            {
+                _inventoryGrid.SetSelectionColor(_selectedInventorySlotColor);
+                _inventoryGrid.ItemSelected += OnInventoryItemSelected;
             }
 
             if (_cancelButton != null)
             {
                 _cancelButton.onClick.AddListener(OnCancelButton);
             }
+
+            _detailsPanel?.Hide();
         }
 
         protected override void OnDeinitialize()
         {
             if (_inventoryGrid != null)
             {
+                _inventoryGrid.ItemSelected -= OnInventoryItemSelected;
                 _inventoryGrid.Bind(null);
             }
 
             if (_hotbar != null)
             {
+                _hotbar.ItemSelected -= OnHotbarItemSelected;
                 _hotbar.Bind(null);
             }
 
@@ -97,6 +113,7 @@ namespace TPSBR.UI
             CanvasGroup.interactable = false;
 
             RefreshInventoryBinding();
+            _detailsPanel?.Hide();
         }
 
         protected override void OnTick()
@@ -121,6 +138,40 @@ namespace TPSBR.UI
         }
 
         // PRIVATE MEMBERS
+
+        private void OnInventoryItemSelected(ItemDefinition definition)
+        {
+            if (definition != null)
+            {
+                _hotbar?.ClearSelection(false);
+            }
+
+            ShowItemDetails(definition);
+        }
+
+        private void OnHotbarItemSelected(ItemDefinition definition)
+        {
+            if (definition != null)
+            {
+                _inventoryGrid?.ClearSelection(false);
+            }
+
+            ShowItemDetails(definition);
+        }
+
+        private void ShowItemDetails(ItemDefinition definition)
+        {
+            if (_detailsPanel == null)
+                return;
+
+            if (definition == null)
+            {
+                _detailsPanel.Hide();
+                return;
+            }
+
+            _detailsPanel.Show(definition);
+        }
 
         private void OnLeaveButton()
         {

--- a/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
+++ b/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using TSS.Data;
 
 namespace TPSBR.UI
 {
@@ -139,38 +138,38 @@ namespace TPSBR.UI
 
         // PRIVATE MEMBERS
 
-        private void OnInventoryItemSelected(ItemDefinition definition)
+        private void OnInventoryItemSelected(Weapon weapon)
         {
-            if (definition != null)
+            if (weapon != null)
             {
                 _hotbar?.ClearSelection(false);
             }
 
-            ShowItemDetails(definition);
+            ShowItemDetails(weapon);
         }
 
-        private void OnHotbarItemSelected(ItemDefinition definition)
+        private void OnHotbarItemSelected(Weapon weapon)
         {
-            if (definition != null)
+            if (weapon != null)
             {
                 _inventoryGrid?.ClearSelection(false);
             }
 
-            ShowItemDetails(definition);
+            ShowItemDetails(weapon);
         }
 
-        private void ShowItemDetails(ItemDefinition definition)
+        private void ShowItemDetails(Weapon weapon)
         {
             if (_detailsPanel == null)
                 return;
 
-            if (definition == null)
+            if (weapon == null)
             {
                 _detailsPanel.Hide();
                 return;
             }
 
-            _detailsPanel.Show(definition);
+            _detailsPanel.Show(weapon);
         }
 
         private void OnLeaveButton()

--- a/Assets/TPSBR/Scripts/UI/Widgets/IUIItemSlotOwner.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/IUIItemSlotOwner.cs
@@ -9,5 +9,6 @@ namespace TPSBR.UI
         void EndSlotDrag(UIItemSlot slot, PointerEventData eventData);
         void HandleSlotDrop(UIItemSlot source, UIItemSlot target);
         void HandleSlotDropOutside(UIItemSlot slot, PointerEventData eventData);
+        void HandleSlotSelected(UIItemSlot slot);
     }
 }

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
@@ -1,4 +1,6 @@
+using System;
 using TPSBR;
+using TSS.Data;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -18,6 +20,11 @@ namespace TPSBR.UI
         private CanvasGroup _dragCanvasGroup;
         private Color _selectionColor = Color.white;
         private int _lastSelectedSlot = -1;
+        [SerializeField]
+        private Color _selectedSlotColor = Color.white;
+        internal event Action<ItemDefinition> ItemSelected;
+
+        private int _selectedSlotIndex = -1;
 
         protected override void OnInitialize()
         {
@@ -31,6 +38,7 @@ namespace TPSBR.UI
             }
 
             UpdateSelection(true);
+            UpdateSelectionHighlight();
         }
 
         protected override void OnDeinitialize()
@@ -71,8 +79,10 @@ namespace TPSBR.UI
 
             SetDragVisible(false);
             _dragSource = null;
+            ClearSelection();
 
             UpdateSelection(true);
+            UpdateSelectionHighlight();
         }
 
         internal void SetSelectedColor(Color color)
@@ -82,6 +92,15 @@ namespace TPSBR.UI
 
             _selectionColor = color;
             UpdateSelection(true);
+        }
+
+        internal void SetSelectionHighlightColor(Color color)
+        {
+            if (_selectedSlotColor == color)
+                return;
+
+            _selectedSlotColor = color;
+            UpdateSelectionHighlight();
         }
 
         protected override void OnTick()
@@ -149,6 +168,53 @@ namespace TPSBR.UI
             _inventory.RequestDropHotbar(slot.Index);
         }
 
+        void IUIItemSlotOwner.HandleSlotSelected(UIItemSlot slot)
+        {
+            if (_inventory == null || slot == null)
+            {
+                ClearSelection();
+                return;
+            }
+
+            var weapon = _inventory.GetWeapon(slot.Index + 1);
+
+            if (weapon == null)
+            {
+                ClearSelection();
+                return;
+            }
+
+            if (_selectedSlotIndex == slot.Index)
+            {
+                NotifySelectionChanged(weapon.Definition);
+                return;
+            }
+
+            _selectedSlotIndex = slot.Index;
+            UpdateSelectionHighlight();
+            NotifySelectionChanged(weapon.Definition);
+        }
+
+        internal void ClearSelection(bool notify = true)
+        {
+            if (_selectedSlotIndex < 0)
+            {
+                if (notify == true)
+                {
+                    NotifySelectionChanged(null);
+                }
+                return;
+            }
+
+            _selectedSlotIndex = -1;
+            UpdateSelectionHighlight();
+
+            if (notify == true)
+            {
+                NotifySelectionChanged(null);
+            }
+        }
+
         private void OnHotbarSlotChanged(int index, Weapon weapon)
         {
             int slotIndex = index - 1;
@@ -169,10 +235,21 @@ namespace TPSBR.UI
             if (weapon == null)
             {
                 _slots[index].Clear();
+                if (_selectedSlotIndex == index)
+                {
+                    _selectedSlotIndex = -1;
+                    UpdateSelectionHighlight();
+                    NotifySelectionChanged(null);
+                }
                 return;
             }
 
             _slots[index].SetItem(weapon.Icon, 1);
+
+            if (_selectedSlotIndex == index)
+            {
+                NotifySelectionChanged(weapon.Definition);
+            }
         }
 
         private void UpdateSelection(bool forceUpdate = false)
@@ -201,6 +278,25 @@ namespace TPSBR.UI
                 bool isSelected = i == selectedSlot;
                 _slots[i].SetSelected(isSelected, _selectionColor);
             }
+
+            UpdateSelectionHighlight();
+        }
+
+        private void UpdateSelectionHighlight()
+        {
+            if (_slots == null)
+                return;
+
+            for (int i = 0; i < _slots.Length; i++)
+            {
+                bool isSelected = i == _selectedSlotIndex;
+                _slots[i].SetSelectionHighlight(isSelected, _selectedSlotColor);
+            }
+        }
+
+        private void NotifySelectionChanged(ItemDefinition definition)
+        {
+            ItemSelected?.Invoke(definition);
         }
 
         private void EnsureDragVisual()

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
@@ -1,6 +1,5 @@
 using System;
 using TPSBR;
-using TSS.Data;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -22,7 +21,7 @@ namespace TPSBR.UI
         private int _lastSelectedSlot = -1;
         [SerializeField]
         private Color _selectedSlotColor = Color.white;
-        internal event Action<ItemDefinition> ItemSelected;
+        internal event Action<Weapon> ItemSelected;
 
         private int _selectedSlotIndex = -1;
 
@@ -186,13 +185,13 @@ namespace TPSBR.UI
 
             if (_selectedSlotIndex == slot.Index)
             {
-                NotifySelectionChanged(weapon.Definition);
+                NotifySelectionChanged(weapon);
                 return;
             }
 
             _selectedSlotIndex = slot.Index;
             UpdateSelectionHighlight();
-            NotifySelectionChanged(weapon.Definition);
+            NotifySelectionChanged(weapon);
         }
 
         internal void ClearSelection(bool notify = true)
@@ -248,7 +247,7 @@ namespace TPSBR.UI
 
             if (_selectedSlotIndex == index)
             {
-                NotifySelectionChanged(weapon.Definition);
+                NotifySelectionChanged(weapon);
             }
         }
 
@@ -294,9 +293,9 @@ namespace TPSBR.UI
             }
         }
 
-        private void NotifySelectionChanged(ItemDefinition definition)
+        private void NotifySelectionChanged(Weapon weapon)
         {
-            ItemSelected?.Invoke(definition);
+            ItemSelected?.Invoke(weapon);
         }
 
         private void EnsureDragVisual()

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryDetailsPanel.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryDetailsPanel.cs
@@ -1,0 +1,102 @@
+using TMPro;
+using TSS.Data;
+using Unity.Template.CompetitiveActionMultiplayer;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace TPSBR.UI
+{
+    public class UIInventoryDetailsPanel : UIWidget
+    {
+        [SerializeField] private CanvasGroup _canvasGroup;
+        [SerializeField] private TextMeshProUGUI _nameLabel;
+        [SerializeField] private TextMeshProUGUI _descriptionLabel;
+        [SerializeField] private Image _iconImage;
+
+        protected override void OnInitialize()
+        {
+            base.OnInitialize();
+
+            Hide();
+        }
+
+        internal void Show(ItemDefinition definition)
+        {
+            if (definition == null)
+            {
+                Hide();
+                return;
+            }
+
+            if (_nameLabel != null)
+            {
+                _nameLabel.SetTextSafe(definition.Name);
+            }
+
+            if (_descriptionLabel != null)
+            {
+                _descriptionLabel.SetTextSafe(GetDescription(definition));
+            }
+
+            if (_iconImage != null)
+            {
+                var sprite = definition.IconSprite;
+                _iconImage.sprite = sprite;
+                _iconImage.enabled = sprite != null;
+            }
+
+            SetVisible(true);
+        }
+
+        internal void Hide()
+        {
+            if (_nameLabel != null)
+            {
+                _nameLabel.SetTextSafe(string.Empty);
+            }
+
+            if (_descriptionLabel != null)
+            {
+                _descriptionLabel.SetTextSafe(string.Empty);
+            }
+
+            if (_iconImage != null)
+            {
+                _iconImage.sprite = null;
+                _iconImage.enabled = false;
+            }
+
+            SetVisible(false);
+        }
+
+        private void SetVisible(bool visible)
+        {
+            if (_canvasGroup != null)
+            {
+                _canvasGroup.SetVisibility(visible);
+
+                if (visible == true && gameObject.activeSelf == false)
+                {
+                    gameObject.SetActive(true);
+                }
+
+                return;
+            }
+
+            if (gameObject.activeSelf != visible)
+            {
+                gameObject.SetActive(visible);
+            }
+        }
+
+        private string GetDescription(ItemDefinition definition)
+        {
+            if (definition is WeaponDefinition weaponDefinition)
+            {
+                return weaponDefinition.Description;
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryDetailsPanel.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryDetailsPanel.cs
@@ -1,6 +1,4 @@
 using TMPro;
-using TSS.Data;
-using Unity.Template.CompetitiveActionMultiplayer;
 using UnityEngine;
 using UnityEngine.UI;
 
@@ -20,9 +18,9 @@ namespace TPSBR.UI
             Hide();
         }
 
-        internal void Show(ItemDefinition definition)
+        internal void Show(Weapon weapon)
         {
-            if (definition == null)
+            if (weapon == null)
             {
                 Hide();
                 return;
@@ -30,17 +28,17 @@ namespace TPSBR.UI
 
             if (_nameLabel != null)
             {
-                _nameLabel.SetTextSafe(definition.Name);
+                _nameLabel.SetTextSafe(weapon.DisplayName);
             }
 
             if (_descriptionLabel != null)
             {
-                _descriptionLabel.SetTextSafe(GetDescription(definition));
+                _descriptionLabel.SetTextSafe(weapon.GetDescription());
             }
 
             if (_iconImage != null)
             {
-                var sprite = definition.IconSprite;
+                var sprite = weapon.Icon;
                 _iconImage.sprite = sprite;
                 _iconImage.enabled = sprite != null;
             }
@@ -89,14 +87,5 @@ namespace TPSBR.UI
             }
         }
 
-        private string GetDescription(ItemDefinition definition)
-        {
-            if (definition is WeaponDefinition weaponDefinition)
-            {
-                return weaponDefinition.Description;
-            }
-
-            return string.Empty;
-        }
     }
 }

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
@@ -1,8 +1,8 @@
 using System;
-using TSS.Data;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
+using Unity.Template.CompetitiveActionMultiplayer;
 
 namespace TPSBR.UI
 {
@@ -19,7 +19,7 @@ namespace TPSBR.UI
                 private CanvasGroup _dragCanvasGroup;
                 [SerializeField]
                 private Color _selectedSlotColor = Color.white;
-                internal event Action<ItemDefinition> ItemSelected;
+                internal event Action<Weapon> ItemSelected;
 
                 private int _selectedSlotIndex = -1;
 
@@ -255,7 +255,8 @@ namespace TPSBR.UI
                                 return;
                         }
 
-                        ItemSelected.Invoke(slot.GetDefinition());
+                        var definition = slot.GetDefinition() as WeaponDefinition;
+                        ItemSelected.Invoke(definition != null ? definition.WeaponPrefab : null);
                 }
 
                 private void EnsureDragVisual()

--- a/Assets/TPSBR/UI/UIItemSlot.cs
+++ b/Assets/TPSBR/UI/UIItemSlot.cs
@@ -6,7 +6,7 @@ using UnityEngine.UI;
 
 namespace TPSBR.UI
 {
-    public class UIItemSlot : UIWidget, IBeginDragHandler, IDragHandler, IEndDragHandler, IDropHandler
+    public class UIItemSlot : UIWidget, IBeginDragHandler, IDragHandler, IEndDragHandler, IDropHandler, IPointerClickHandler
     {
         private static readonly Dictionary<int, UIItemSlot> _lastDropTargets = new Dictionary<int, UIItemSlot>();
         private static readonly List<RaycastResult> _raycastResults = new List<RaycastResult>();
@@ -14,6 +14,7 @@ namespace TPSBR.UI
         private static UIItemSlot _activeDragSlot;
 
         [SerializeField] private Image _backgroundImage;
+        [SerializeField] private Image _selectionBorderImage;
 
         private IUIItemSlotOwner _owner;
         private UIButton _button;
@@ -25,6 +26,8 @@ namespace TPSBR.UI
         private bool _isDragging;
         private Color _defaultBackgroundColor;
         private bool _defaultBackgroundColorCached;
+        private Color _defaultSelectionBorderColor;
+        private bool _defaultSelectionBorderColorCached;
 
         public int Index { get; private set; } = -1;
         public RectTransform SlotRectTransform => RectTransform;
@@ -40,6 +43,7 @@ namespace TPSBR.UI
             EnsureCanvasGroup();
 
             CacheDefaultBackgroundColor();
+            CacheDefaultSelectionBorderColor();
 
             if (_allSlots.Contains(this) == false)
             {
@@ -176,6 +180,17 @@ namespace TPSBR.UI
             _owner.HandleSlotDrop(sourceSlot, this);
         }
 
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            if (_owner == null || eventData == null)
+                return;
+
+            if (eventData.button != PointerEventData.InputButton.Left)
+                return;
+
+            _owner.HandleSlotSelected(this);
+        }
+
         internal IUIItemSlotOwner Owner => _owner;
 
         internal void SetSelected(bool selected, Color selectedColor)
@@ -186,6 +201,16 @@ namespace TPSBR.UI
             CacheDefaultBackgroundColor();
 
             _backgroundImage.color = selected ? selectedColor : _defaultBackgroundColor;
+        }
+
+        internal void SetSelectionHighlight(bool selected, Color selectedColor)
+        {
+            if (_selectionBorderImage == null)
+                return;
+
+            CacheDefaultSelectionBorderColor();
+
+            _selectionBorderImage.color = selected ? selectedColor : _defaultSelectionBorderColor;
         }
 
         private void EnsureCanvasGroup()
@@ -207,6 +232,15 @@ namespace TPSBR.UI
 
             _defaultBackgroundColor = _backgroundImage.color;
             _defaultBackgroundColorCached = true;
+        }
+
+        private void CacheDefaultSelectionBorderColor()
+        {
+            if (_selectionBorderImage == null || _defaultSelectionBorderColorCached == true)
+                return;
+
+            _defaultSelectionBorderColor = _selectionBorderImage.color;
+            _defaultSelectionBorderColorCached = true;
         }
 
         private void EnsureIconImage()

--- a/Assets/TSS/WeaponDefinition.cs
+++ b/Assets/TSS/WeaponDefinition.cs
@@ -8,8 +8,11 @@ namespace Unity.Template.CompetitiveActionMultiplayer
     {
         [SerializeField]
         private Weapon _weaponPrefab;
+        [SerializeField, TextArea]
+        private string _description;
 
         public Weapon WeaponPrefab => _weaponPrefab;
         public override ushort MaxStack => 1;
+        public string Description => _description;
     }
 }

--- a/Assets/TSS/WeaponDefinition.cs
+++ b/Assets/TSS/WeaponDefinition.cs
@@ -8,11 +8,7 @@ namespace Unity.Template.CompetitiveActionMultiplayer
     {
         [SerializeField]
         private Weapon _weaponPrefab;
-        [SerializeField, TextArea]
-        private string _description;
-
         public Weapon WeaponPrefab => _weaponPrefab;
         public override ushort MaxStack => 1;
-        public string Description => _description;
     }
 }


### PR DESCRIPTION
## Summary
- add a reusable inventory details panel that shows the selected item’s name, icon, and description
- enable inventory and hotbar slots to report left-click selection events and update their selection border colors
- wire the gameplay inventory view to drive the details panel, manage selection colors, and clear selection on inventory updates
- extend weapon definitions with a serialized description field for displaying stats

## Testing
- not run (Unity project)

------
https://chatgpt.com/codex/tasks/task_b_68e5cfa09f5083269bdf45f896df5157