### PR TITLE
Derive staff weapon description from configuration hash

### DIFF
--- a/Assets/TPSBR/Scripts/Gameplay/Weapons/StaffWeapon.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Weapons/StaffWeapon.cs
@@ -1,4 +1,5 @@
 using System;
+using Fusion;
 using UnityEngine;
 
 namespace TPSBR
@@ -203,22 +204,49 @@ namespace TPSBR
 
         public override string GetDescription()
         {
-            float baseDamage = _baseDamage;
-            float healthRegen = _healthRegen;
-            float manaRegen = _manaRegen;
-
-            if (TryGetStatsFromConfiguration(_lastConfigurationHash, out float configBaseDamage, out float configHealthRegen, out float configManaRegen, out _))
+            if (TryGetStatsFromConfiguration(_lastConfigurationHash, out float baseDamage, out float healthRegen, out float manaRegen, out _))
             {
-                baseDamage = configBaseDamage;
-                healthRegen = configHealthRegen;
-                manaRegen = configManaRegen;
+                return BuildDescription(baseDamage, healthRegen, manaRegen);
             }
 
+            return BuildDescription(_baseDamage, _healthRegen, _manaRegen);
+        }
+
+        public override string GetDescription(NetworkString<_32> configurationHash)
+        {
+            string hash = configurationHash.ToString();
+
+            if (TryGetStatsFromConfiguration(hash, out float baseDamage, out float healthRegen, out float manaRegen, out _))
+            {
+                return BuildDescription(baseDamage, healthRegen, manaRegen);
+            }
+
+            return GetDescription();
+        }
+
+        public override string GetDisplayName(NetworkString<_32> configurationHash)
+        {
+            string hash = configurationHash.ToString();
+
+            if (TryGetStatsFromConfiguration(hash, out _, out _, out _, out string configuredItemName) == true && string.IsNullOrWhiteSpace(configuredItemName) == false)
+            {
+                return configuredItemName;
+            }
+
+            if (string.IsNullOrWhiteSpace(_configuredItemName) == false)
+            {
+                return _configuredItemName;
+            }
+
+            return base.GetDisplayName(configurationHash);
+        }
+
+        private string BuildDescription(float baseDamage, float healthRegen, float manaRegen)
+        {
             return
-                   $"Damage: {baseDamage}\n" +
-                   $"Health Regen: {healthRegen}\n" +
-                   $"Mana Regen: {manaRegen}\n" +
-                   $"" ;
+                $"Damage: {baseDamage}\n" +
+                $"Health Regen: {healthRegen}\n" +
+                $"Mana Regen: {manaRegen}";
         }
     }
 }

--- a/Assets/TPSBR/Scripts/Gameplay/Weapons/StaffWeapon.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Weapons/StaffWeapon.cs
@@ -16,6 +16,8 @@ namespace TPSBR
         [SerializeField]
         private string _configuredItemName;
 
+        private string _lastConfigurationHash = string.Empty;
+
         public float BaseDamage => _baseDamage;
         public float HealthRegen => _healthRegen;
         public float ManaRegen => _manaRegen;
@@ -56,6 +58,7 @@ namespace TPSBR
                 return;
             }
 
+            _lastConfigurationHash = configurationHash;
             ApplyConfiguration(baseDamage, healthRegen, manaRegen, configuredItemName);
         }
 
@@ -135,6 +138,7 @@ namespace TPSBR
             _healthRegen = 0f;
             _manaRegen = 0f;
             _configuredItemName = string.Empty;
+            _lastConfigurationHash = string.Empty;
 
             SetWeaponSize(WeaponSize.Unarmed);
             SetDisplayName(string.Empty);
@@ -203,7 +207,7 @@ namespace TPSBR
             float healthRegen = _healthRegen;
             float manaRegen = _manaRegen;
 
-            if (TryGetStatsFromConfiguration(ConfigurationHash.ToString(), out float configBaseDamage, out float configHealthRegen, out float configManaRegen, out _))
+            if (TryGetStatsFromConfiguration(_lastConfigurationHash, out float configBaseDamage, out float configHealthRegen, out float configManaRegen, out _))
             {
                 baseDamage = configBaseDamage;
                 healthRegen = configHealthRegen;

--- a/Assets/TPSBR/Scripts/Gameplay/Weapons/StaffWeapon.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Weapons/StaffWeapon.cs
@@ -50,13 +50,13 @@ namespace TPSBR
         {
             base.OnConfigurationHashApplied(configurationHash);
 
-            if (TryParseSeed(configurationHash, out int seed) == false)
+            if (TryGetStatsFromConfiguration(configurationHash, out float baseDamage, out float healthRegen, out float manaRegen, out string configuredItemName) == false)
             {
                 ResetConfiguration();
                 return;
             }
 
-            ApplyConfiguration(seed);
+            ApplyConfiguration(baseDamage, healthRegen, manaRegen, configuredItemName);
         }
 
         private bool TryParseSeed(string configurationHash, out int seed)
@@ -92,19 +92,41 @@ namespace TPSBR
             }
         }
 
-        private void ApplyConfiguration(int seed)
+        private void ApplyConfiguration(float baseDamage, float healthRegen, float manaRegen, string configuredItemName)
         {
-            var random = new System.Random(seed);
-
-            _baseDamage = GenerateStat(random, 18f, 32f, 0.5f);
-            _healthRegen = GenerateStat(random, 1f, 6f, 0.1f);
-            _manaRegen = GenerateStat(random, 2f, 9f, 0.1f);
-
-            _configuredItemName = GenerateName(random);
+            _baseDamage = baseDamage;
+            _healthRegen = healthRegen;
+            _manaRegen = manaRegen;
+            _configuredItemName = configuredItemName;
 
             SetWeaponSize(WeaponSize.Staff);
             SetDisplayName(_configuredItemName);
             SetNameShortcut(CreateShortcut(_configuredItemName));
+        }
+
+        private bool TryGetStatsFromConfiguration(string configurationHash, out float baseDamage, out float healthRegen, out float manaRegen, out string configuredItemName)
+        {
+            baseDamage = default;
+            healthRegen = default;
+            manaRegen = default;
+            configuredItemName = string.Empty;
+
+            if (TryParseSeed(configurationHash, out int seed) == false)
+            {
+                return false;
+            }
+
+            PopulateStats(new System.Random(seed), out baseDamage, out healthRegen, out manaRegen, out configuredItemName);
+
+            return true;
+        }
+
+        private void PopulateStats(System.Random random, out float baseDamage, out float healthRegen, out float manaRegen, out string configuredItemName)
+        {
+            baseDamage = GenerateStat(random, 18f, 32f, 0.5f);
+            healthRegen = GenerateStat(random, 1f, 6f, 0.1f);
+            manaRegen = GenerateStat(random, 2f, 9f, 0.1f);
+            configuredItemName = GenerateName(random);
         }
 
         private void ResetConfiguration()
@@ -177,10 +199,21 @@ namespace TPSBR
 
         public override string GetDescription()
         {
-            return 
-                   $"Damage: {_baseDamage}\n" +
-                   $"Health Regen: {_healthRegen}\n" +
-                   $"Mana Regen: {_manaRegen}\n" +
+            float baseDamage = _baseDamage;
+            float healthRegen = _healthRegen;
+            float manaRegen = _manaRegen;
+
+            if (TryGetStatsFromConfiguration(ConfigurationHash.ToString(), out float configBaseDamage, out float configHealthRegen, out float configManaRegen, out _))
+            {
+                baseDamage = configBaseDamage;
+                healthRegen = configHealthRegen;
+                manaRegen = configManaRegen;
+            }
+
+            return
+                   $"Damage: {baseDamage}\n" +
+                   $"Health Regen: {healthRegen}\n" +
+                   $"Mana Regen: {manaRegen}\n" +
                    $"" ;
         }
     }

--- a/Assets/TPSBR/Scripts/Gameplay/Weapons/Weapon.cs
+++ b/Assets/TPSBR/Scripts/Gameplay/Weapons/Weapon.cs
@@ -20,6 +20,14 @@ namespace TPSBR
         {
             return _description + " this is the description";
         }
+        public virtual string GetDisplayName(NetworkString<_32> configurationHash)
+        {
+            return DisplayName;
+        }
+        public virtual string GetDescription(NetworkString<_32> configurationHash)
+        {
+            return GetDescription();
+        }
         public bool ValidOnlyWithAmmo => _validOnlyWithAmmo;
         public bool IsInitialized => _isInitialized;
         public bool IsArmed => _isArmed;

--- a/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
+++ b/Assets/TPSBR/Scripts/UI/GameplayViews/UIGameplayInventory.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using Fusion;
+using UnityEngine;
 
 namespace TPSBR.UI
 {
@@ -138,27 +139,27 @@ namespace TPSBR.UI
 
         // PRIVATE MEMBERS
 
-        private void OnInventoryItemSelected(Weapon weapon)
+        private void OnInventoryItemSelected(Weapon weapon, NetworkString<_32> configurationHash)
         {
             if (weapon != null)
             {
                 _hotbar?.ClearSelection(false);
             }
 
-            ShowItemDetails(weapon);
+            ShowItemDetails(weapon, configurationHash);
         }
 
-        private void OnHotbarItemSelected(Weapon weapon)
+        private void OnHotbarItemSelected(Weapon weapon, NetworkString<_32> configurationHash)
         {
             if (weapon != null)
             {
                 _inventoryGrid?.ClearSelection(false);
             }
 
-            ShowItemDetails(weapon);
+            ShowItemDetails(weapon, configurationHash);
         }
 
-        private void ShowItemDetails(Weapon weapon)
+        private void ShowItemDetails(Weapon weapon, NetworkString<_32> configurationHash)
         {
             if (_detailsPanel == null)
                 return;
@@ -169,7 +170,7 @@ namespace TPSBR.UI
                 return;
             }
 
-            _detailsPanel.Show(weapon);
+            _detailsPanel.Show(weapon, configurationHash);
         }
 
         private void OnLeaveButton()

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIHotbar.cs
@@ -1,4 +1,5 @@
 using System;
+using Fusion;
 using TPSBR;
 using UnityEngine;
 using UnityEngine.EventSystems;
@@ -21,7 +22,7 @@ namespace TPSBR.UI
         private int _lastSelectedSlot = -1;
         [SerializeField]
         private Color _selectedSlotColor = Color.white;
-        internal event Action<Weapon> ItemSelected;
+        internal event Action<Weapon, NetworkString<_32>> ItemSelected;
 
         private int _selectedSlotIndex = -1;
 
@@ -295,7 +296,14 @@ namespace TPSBR.UI
 
         private void NotifySelectionChanged(Weapon weapon)
         {
-            ItemSelected?.Invoke(weapon);
+            NetworkString<_32> configurationHash = default;
+
+            if (weapon != null)
+            {
+                configurationHash = weapon.ConfigurationHash;
+            }
+
+            ItemSelected?.Invoke(weapon, configurationHash);
         }
 
         private void EnsureDragVisual()

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryDetailsPanel.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryDetailsPanel.cs
@@ -1,3 +1,4 @@
+using Fusion;
 using TMPro;
 using UnityEngine;
 using UnityEngine.UI;
@@ -18,7 +19,7 @@ namespace TPSBR.UI
             Hide();
         }
 
-        internal void Show(Weapon weapon)
+        internal void Show(Weapon weapon, NetworkString<_32> configurationHash)
         {
             if (weapon == null)
             {
@@ -28,12 +29,24 @@ namespace TPSBR.UI
 
             if (_nameLabel != null)
             {
-                _nameLabel.SetTextSafe(weapon.DisplayName);
+                string displayName = weapon.GetDisplayName(configurationHash);
+                if (string.IsNullOrWhiteSpace(displayName) == true)
+                {
+                    displayName = weapon.DisplayName;
+                }
+
+                _nameLabel.SetTextSafe(displayName);
             }
 
             if (_descriptionLabel != null)
             {
-                _descriptionLabel.SetTextSafe(weapon.GetDescription());
+                string description = weapon.GetDescription(configurationHash);
+                if (string.IsNullOrWhiteSpace(description) == true)
+                {
+                    description = weapon.GetDescription();
+                }
+
+                _descriptionLabel.SetTextSafe(description);
             }
 
             if (_iconImage != null)

--- a/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
+++ b/Assets/TPSBR/Scripts/UI/Widgets/UIInventoryGrid.cs
@@ -1,4 +1,5 @@
 using System;
+using Fusion;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -19,7 +20,7 @@ namespace TPSBR.UI
                 private CanvasGroup _dragCanvasGroup;
                 [SerializeField]
                 private Color _selectedSlotColor = Color.white;
-                internal event Action<Weapon> ItemSelected;
+                internal event Action<Weapon, NetworkString<_32>> ItemSelected;
 
                 private int _selectedSlotIndex = -1;
 
@@ -243,7 +244,7 @@ namespace TPSBR.UI
 
                         if (_inventory == null || _selectedSlotIndex < 0)
                         {
-                                ItemSelected.Invoke(null);
+                                ItemSelected.Invoke(null, default);
                                 return;
                         }
 
@@ -251,12 +252,12 @@ namespace TPSBR.UI
 
                         if (slot.IsEmpty)
                         {
-                                ItemSelected.Invoke(null);
+                                ItemSelected.Invoke(null, default);
                                 return;
                         }
 
                         var definition = slot.GetDefinition() as WeaponDefinition;
-                        ItemSelected.Invoke(definition != null ? definition.WeaponPrefab : null);
+                        ItemSelected.Invoke(definition != null ? definition.WeaponPrefab : null, slot.ConfigurationHash);
                 }
 
                 private void EnsureDragVisual()


### PR DESCRIPTION
## Summary
- derive staff weapon stats from its configuration hash so descriptions work even when the physical item is absent
- share stat generation logic to avoid duplication when applying configurations and building descriptions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e5dde8602883268328ce7f92a24f80